### PR TITLE
chore: polyfill Node globals for Vite build

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "autoprefixer": "^10.4.14",
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.3",
-    "vite": "^5.0.0"
+    "vite": "^5.0.0",
+    "vite-plugin-node-polyfills": "^0.21.0"
   }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,11 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import nodePolyfills from 'vite-plugin-node-polyfills';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), nodePolyfills()],
+  define: {
+    __dirname: JSON.stringify(new URL('.', import.meta.url).pathname),
+  },
 });


### PR DESCRIPTION
## Summary
- add `vite-plugin-node-polyfills` and `__dirname` fallback in Vite config
- include polyfill plugin in dev dependencies

## Testing
- `npm install --no-progress` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afe4b94700832b9076ea18fe6e94a5