### PR TITLE
chore: use named node polyfills import

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import nodePolyfills from 'vite-plugin-node-polyfills';
+import { nodePolyfills } from 'vite-plugin-node-polyfills';
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- use named import for node polyfills plugin

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afe9660c80832ba410c56a2e0b2f38