### PR TITLE
Add Express backend for astrology API with Vite proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,15 @@ A single-page React application that renders an accurate North Indian style D1 (
 npm install
 
 # Run in development
+# Start the backend in a separate terminal
+npm run server
+# Then launch the Vite dev server
 npm run dev
 ```
 
 1. Clone this repository.
 2. Install dependencies with `npm install`.
-3. Start the development server using `npm run dev`.
+3. Start the backend with `npm run server` and in another terminal run `npm run dev`.
 
 ### Preparing the offline location dataset
 

--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/index.js"
   },
   "dependencies": {
+    "express": "^4.18.2",
+    "jyotish-calculations": "*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,71 @@
+const express = require('express');
+const jyotish = require('jyotish-calculations');
+
+const app = express();
+const PORT = process.env.PORT || 3001;
+
+async function computeAscendant(date, lat, lon) {
+  if (jyotish.getAscendant) {
+    return await jyotish.getAscendant(date, lat, lon);
+  }
+  if (jyotish.ascendant) {
+    return await jyotish.ascendant(date, lat, lon);
+  }
+  if (jyotish.getAscendantLongitude) {
+    return await jyotish.getAscendantLongitude(date, lat, lon);
+  }
+  throw new Error('Ascendant calculation not available');
+}
+
+async function computePlanet(date, lat, lon, planet) {
+  if (jyotish.getPlanetPosition) {
+    return await jyotish.getPlanetPosition(planet, date, lat, lon);
+  }
+  if (jyotish.getPlanet) {
+    return await jyotish.getPlanet(planet, date, lat, lon);
+  }
+  if (jyotish.planet) {
+    return await jyotish.planet(planet, date, lat, lon);
+  }
+  throw new Error('Planet calculation not available');
+}
+
+app.get('/api/ascendant', async (req, res) => {
+  const { date, lat, lon } = req.query;
+  if (!date || !lat || !lon) {
+    res.status(400).json({ error: 'Missing query parameters' });
+    return;
+  }
+  try {
+    const jsDate = new Date(date);
+    const result = await computeAscendant(jsDate, parseFloat(lat), parseFloat(lon));
+    const longitude = typeof result === 'number' ? result : result.longitude;
+    res.json({ longitude });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.get('/api/planet', async (req, res) => {
+  const { date, lat, lon, planet } = req.query;
+  if (!date || !lat || !lon || !planet) {
+    res.status(400).json({ error: 'Missing query parameters' });
+    return;
+  }
+  try {
+    const jsDate = new Date(date);
+    const result = await computePlanet(jsDate, parseFloat(lat), parseFloat(lon), planet);
+    res.json({
+      longitude: result.longitude ?? result.lng ?? result.lon ?? result.longitudeDeg,
+      retrograde: result.retrograde ?? result.isRetrograde ?? false,
+      combust: result.combust ?? result.isCombust ?? false,
+    });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});
+

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,4 +8,9 @@ export default defineConfig({
   define: {
     __dirname: JSON.stringify(new URL('.', import.meta.url).pathname),
   },
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3001',
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- add Express server providing `/api/ascendant` and `/api/planet` endpoints
- proxy Vite dev server `/api` requests to backend
- document running backend alongside frontend

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-react)*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: vite: not found)*
- `npm run server` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68aff83e0440832bb3bb29f76fd5653e