### PR TITLE
Graceful API error handling for chart calculations

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,7 @@ export default function App() {
       setChartData(data);
     } catch (err) {
       console.error(err);
-      setError('Failed to calculate chart.');
+      setError(err.message || 'Failed to calculate chart.');
     } finally {
       setLoading(false);
     }

--- a/src/calculateChart.js
+++ b/src/calculateChart.js
@@ -12,6 +12,9 @@ async function getAscendant(jsDate, lat, lon) {
 
   const res = await fetch(`/api/ascendant?${params.toString()}`);
   const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.error || 'Failed to fetch ascendant');
+  }
   return data.longitude;
 }
 
@@ -24,7 +27,11 @@ async function getPlanetPosition(jsDate, lat, lon, planet) {
   });
 
   const res = await fetch(`/api/planet?${params.toString()}`);
-  return res.json();
+  const data = await res.json();
+  if (!res.ok) {
+    throw new Error(data.error || `Failed to fetch ${planet} position`);
+  }
+  return data;
 }
 
 const PLANETS = [


### PR DESCRIPTION
## Summary
- Throw errors with backend messages when ascendant or planet lookups fail
- Display calculation error details in the UI instead of a generic message

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)

------
https://chatgpt.com/codex/tasks/task_e_68affc6fa600832b8108a44c4a174283