### PR TITLE
Handle server errors and surface messages in UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ export default function App() {
   const handleSubmit = async (form) => {
     setLoading(true);
     setError('');
+    setChartData(null);
     try {
       const data = await calculateChart(form);
       setChartData(data);

--- a/src/calculateChart.js
+++ b/src/calculateChart.js
@@ -11,10 +11,14 @@ async function getAscendant(jsDate, lat, lon) {
   });
 
   const res = await fetch(`/api/ascendant?${params.toString()}`);
-  const data = await res.json();
   if (!res.ok) {
-    throw new Error(data.error || 'Request failed');
+    let data = {};
+    try {
+      data = await res.json();
+    } catch (e) {}
+    throw new Error(data.error || res.statusText);
   }
+  const data = await res.json();
   return data.longitude;
 }
 
@@ -27,10 +31,14 @@ async function getPlanetPosition(jsDate, lat, lon, planet) {
   });
 
   const res = await fetch(`/api/planet?${params.toString()}`);
-  const data = await res.json();
   if (!res.ok) {
-    throw new Error(data.error || 'Request failed');
+    let data = {};
+    try {
+      data = await res.json();
+    } catch (e) {}
+    throw new Error(data.error || res.statusText);
   }
+  const data = await res.json();
   return data;
 }
 


### PR DESCRIPTION
## Summary
- Verify backend responses in `calculateChart` helpers and surface server error messages
- Reset chart data on submit and show server error message in `App`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b00fe85364832b8dd923a12bad4068