### PR TITLE
Use direct jyotish helpers

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -26,11 +26,11 @@ const app = express();
 const PORT = process.env.PORT || 3001;
 
 async function computeAscendant(date, lat, lon) {
-  return await jyotish.getAscendantLongitude(date, lat, lon);
+  return jyotish.getAscendantLongitude(date, lat, lon);
 }
 
 async function computePlanet(date, lat, lon, planetName) {
-  return await jyotish.getPlanetLongitude(planetName, date, lat, lon);
+  return jyotish.getPlanetPosition(planetName, date, lat, lon);
 }
 
 app.get('/api/ascendant', async (req, res) => {
@@ -41,8 +41,7 @@ app.get('/api/ascendant', async (req, res) => {
   }
   try {
     const jsDate = new Date(date);
-    const result = await computeAscendant(jsDate, parseFloat(lat), parseFloat(lon));
-    const longitude = typeof result === 'number' ? result : result.longitude;
+    const longitude = await computeAscendant(jsDate, parseFloat(lat), parseFloat(lon));
     res.json({ longitude });
   } catch (err) {
     res.status(500).json({ error: err.message });
@@ -57,12 +56,13 @@ app.get('/api/planet', async (req, res) => {
   }
   try {
     const jsDate = new Date(date);
-    const result = await computePlanet(jsDate, parseFloat(lat), parseFloat(lon), planet);
-    res.json({
-      longitude: result.longitude ?? result.lng ?? result.lon ?? result.longitudeDeg,
-      retrograde: result.retrograde ?? result.isRetrograde ?? false,
-      combust: result.combust ?? result.isCombust ?? false,
-    });
+    const { longitude, retrograde, combust } = await computePlanet(
+      jsDate,
+      parseFloat(lat),
+      parseFloat(lon),
+      planet
+    );
+    res.json({ longitude, retrograde, combust });
   } catch (err) {
     res.status(500).json({ error: err.message });
   }


### PR DESCRIPTION
## Summary
- Remove fallback chains in server endpoints and call direct `jyotish-calculations` helpers
- Simplify ascendant and planet computations to rely on `getAscendantLongitude` and `getPlanetPosition`

## Testing
- `node -e "console.log(require('jyotish-calculations'))"` *(fails: Cannot find module 'jyotish-calculations')*
- `npm test` *(fails: Missing script "test")*
- `node server/index.js` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68b0115ac390832bbd5259f6628a39d1