### PR TITLE
Initialize ephemeris before server start

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -22,6 +22,13 @@ if (!fs.existsSync(ephemerisPath)) {
   process.exit(1);
 }
 
+try {
+  jyotish.setEphemerisPath(ephemerisPath);
+} catch (err) {
+  console.error('Failed to initialize jyotish-calculations:', err);
+  process.exit(1);
+}
+
 const app = express();
 const PORT = process.env.PORT || 3001;
 
@@ -68,24 +75,7 @@ app.get('/api/planet', async (req, res) => {
   }
 });
 
-async function start() {
-  try {
-    if (typeof jyotish.setEphemerisPath === 'function') {
-      await jyotish.setEphemerisPath(ephemerisPath);
-    } else if (typeof jyotish.init === 'function') {
-      await jyotish.init(ephemerisPath);
-    } else {
-      throw new Error('jyotish-calculations missing initialization function');
-    }
-
-    app.listen(PORT, () => {
-      console.log(`Server listening on port ${PORT}`);
-    });
-  } catch (err) {
-    console.error('Failed to initialize jyotish-calculations:', err);
-    process.exit(1);
-  }
-}
-
-start();
+app.listen(PORT, () => {
+  console.log(`Server listening on port ${PORT}`);
+});
 


### PR DESCRIPTION
## Summary
- Set Swiss Ephemeris path on jyotish-calculations immediately after requiring the library.
- Exit with an error if the ephemeris path is missing or initialization fails.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b01227e8a4832b8ec429d40dbcb20b