### PR TITLE
fix: use default jyotish-calculations export

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 // Load the jyotish-calculations API directly and use its documented
 // exports without any fallback logic.
-const jyotish = require('jyotish-calculations');
+const jyotish = require('jyotish-calculations').default;
 
 // Initialize jyotish-calculations with the Swiss Ephemeris path before
 // handling any requests. Exit with a clear error if initialization fails


### PR DESCRIPTION
## Summary
- fix server to import `jyotish-calculations` via its default export

## Testing
- `npm install` *(fails: 403 Forbidden for @vitejs/plugin-react)*
- `npm run server` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b0244e9124832bb7273eb8f279d41e