### PR TITLE
fix: load jyotish-calculations directly

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 // Load the jyotish-calculations API directly and use its documented
 // exports without any fallback logic.
-const jyotish = require('jyotish-calculations').default;
+const jyotish = require('jyotish-calculations');
 
 // Initialize jyotish-calculations with the Swiss Ephemeris path before
 // handling any requests. Exit with a clear error if initialization fails


### PR DESCRIPTION
## Summary
- use direct require for `jyotish-calculations` without accessing `.default`

## Testing
- `npm install` *(fails: 403 Forbidden for @vitejs/plugin-react)*
- `npm run server` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b0258e1e0c832bbbec503789e7ad9e