### PR TITLE
Handle jyotish-calculations default and named exports

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -2,15 +2,9 @@ const fs = require('fs');
 const express = require('express');
 const path = require('path');
 
-
 const jyotishModule = require('jyotish-calculations');
-
-const {
-  setEphemerisPath,
-  getAscendantLongitude,
-  getPlanetPosition,
-} = jyotishModule.default || jyotishModule;
-} = require('jyotish-calculations');
+const { setEphemerisPath, getAscendantLongitude, getPlanetPosition } =
+  jyotishModule.default || jyotishModule;
 
 // Initialize jyotish-calculations with the Swiss Ephemeris path before
 // handling any requests. Exit with a clear error if initialization fails


### PR DESCRIPTION
## Summary
- simplify jyotish-calculations import to avoid trailing commas and support default/named exports

## Testing
- `node --check server/index.js`
- `npm run server` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b05f3dd9b4832ba8077d84e3c14f65