### PR TITLE
Fix ascendant calculation API

### DIFF
--- a/server/index.cjs
+++ b/server/index.cjs
@@ -45,8 +45,9 @@ const PORT = process.env.PORT || 3001;
 // --- API Endpoints ---
 
 async function computeAscendant(date, lat, lon) {
-  // The calculation functions are on the 'jyotish-calculations' object.
-  return jyotish.getAscendantLongitude(date, lat, lon);
+  // The 'getAscendant' function returns an object with a longitude property.
+  const { longitude } = await jyotish.getAscendant(date, lat, lon);
+  return longitude;
 }
 
 async function computePlanet(date, lat, lon, planetName) {


### PR DESCRIPTION
## Summary
- Use `jyotish.getAscendant` and extract longitude for ascendant calculations

## Testing
- `npm test` *(fails: Missing script "test")*
- `node server/index.cjs` *(fails: Cannot find module 'express')*
- `npm install express` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68b0ff452b58832b8afb93b6d8c4209d