### PR TITLE
Add ascendant API integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "server": "node server/index.cjs"
+    "server": "node server/index.cjs",
+    "test": "node --test"
   },
   "dependencies": {
     "express": "^4.18.2",

--- a/server/index.cjs
+++ b/server/index.cjs
@@ -89,7 +89,12 @@ app.get('/api/planet', async (req, res) => {
   }
 });
 
-// Start the server.
-app.listen(PORT, () => {
-  console.log(`Server listening on port ${PORT}`);
-});
+// Start the server only if this file is executed directly.
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+  });
+}
+
+// Export the app for testing purposes.
+module.exports = app;

--- a/tests/api-ascendant.test.js
+++ b/tests/api-ascendant.test.js
@@ -1,0 +1,18 @@
+const assert = require('node:assert');
+const test = require('node:test');
+const app = require('../server/index.cjs');
+
+test('GET /api/ascendant returns numeric longitude', async (t) => {
+  const server = app.listen(0);
+  t.after(() => server.close());
+  await new Promise((resolve) => server.once('listening', resolve));
+  const { port } = server.address();
+  const params = new URLSearchParams({
+    date: '2023-01-01T00:00:00Z',
+    lat: '0',
+    lon: '0'
+  });
+  const res = await fetch(`http://localhost:${port}/api/ascendant?${params}`);
+  const body = await res.json();
+  assert.strictEqual(typeof body.longitude, 'number');
+});


### PR DESCRIPTION
## Summary
- export Express app and start server only when run directly
- add integration test for `/api/ascendant`
- wire test script to run with `npm test`

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b119886cb0832b9fd70a507305df64