### PR TITLE
Expose computeAscendant using Swiss ephemeris

### DIFF
--- a/server/index.cjs
+++ b/server/index.cjs
@@ -109,3 +109,4 @@ if (require.main === module) {
 
 // Export the app for testing purposes.
 module.exports = app;
+module.exports.computeAscendant = computeAscendant;


### PR DESCRIPTION
## Summary
- calculate ascendant using Swiss Ephemeris and export helper
- route /api/ascendant delegates to computeAscendant and no longer uses jyotish.getAscendant

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b1281587dc832b946ae415a56880e2