### PR TITLE
Validate inputs for ascendant and planet endpoints

### DIFF
--- a/server/index.cjs
+++ b/server/index.cjs
@@ -72,7 +72,20 @@ app.get('/api/ascendant', async (req, res) => {
   }
   try {
     const jsDate = new Date(date);
-    const longitude = computeAscendant(jsDate, parseFloat(lat), parseFloat(lon));
+    const latNum = parseFloat(lat);
+    const lonNum = parseFloat(lon);
+
+    if (Number.isNaN(jsDate.getTime())) {
+      return res.status(400).json({ error: 'Invalid date parameter' });
+    }
+    if (!Number.isFinite(latNum)) {
+      return res.status(400).json({ error: 'Invalid latitude parameter' });
+    }
+    if (!Number.isFinite(lonNum)) {
+      return res.status(400).json({ error: 'Invalid longitude parameter' });
+    }
+
+    const longitude = computeAscendant(jsDate, latNum, lonNum);
     res.json({ longitude });
   } catch (err) {
     console.error('Error in /api/ascendant:', err);
@@ -87,11 +100,39 @@ app.get('/api/planet', async (req, res) => {
   }
   try {
     const jsDate = new Date(date);
+    const latNum = parseFloat(lat);
+    const lonNum = parseFloat(lon);
+    const planetName = String(planet).toLowerCase();
+
+    if (Number.isNaN(jsDate.getTime())) {
+      return res.status(400).json({ error: 'Invalid date parameter' });
+    }
+    if (!Number.isFinite(latNum)) {
+      return res.status(400).json({ error: 'Invalid latitude parameter' });
+    }
+    if (!Number.isFinite(lonNum)) {
+      return res.status(400).json({ error: 'Invalid longitude parameter' });
+    }
+    const validPlanets = [
+      'sun',
+      'moon',
+      'mercury',
+      'venus',
+      'mars',
+      'jupiter',
+      'saturn',
+      'rahu',
+      'ketu'
+    ];
+    if (!validPlanets.includes(planetName)) {
+      return res.status(400).json({ error: `Invalid planet parameter: ${planet}` });
+    }
+
     const { longitude, retrograde, combust } = await computePlanet(
       jsDate,
-      parseFloat(lat),
-      parseFloat(lon),
-      planet
+      latNum,
+      lonNum,
+      planetName
     );
     res.json({ longitude, retrograde, combust });
   } catch (err) {


### PR DESCRIPTION
## Summary
- ensure `/api/ascendant` checks date, latitude, and longitude are valid numbers before computation
- validate `/api/planet` inputs and confirm the requested planet is recognized

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b12ac273c4832b93b55e751cf4d096