### PR TITLE
test: add planet API tests

### DIFF
--- a/tests/api-planet.test.js
+++ b/tests/api-planet.test.js
@@ -1,0 +1,36 @@
+const assert = require('node:assert');
+const test = require('node:test');
+const app = require('../server/index.cjs');
+
+test('GET /api/planet returns expected fields', async (t) => {
+  const server = app.listen(0);
+  t.after(() => server.close());
+  await new Promise((resolve) => server.once('listening', resolve));
+  const { port } = server.address();
+  const params = new URLSearchParams({
+    date: '2023-01-01T00:00:00Z',
+    lat: '0',
+    lon: '0',
+    planet: 'sun'
+  });
+  const res = await fetch(`http://localhost:${port}/api/planet?${params}`);
+  assert.strictEqual(res.status, 200);
+  const body = await res.json();
+  assert.strictEqual(typeof body.longitude, 'number');
+  assert.strictEqual(typeof body.retrograde, 'boolean');
+  assert.strictEqual(typeof body.combust, 'boolean');
+});
+
+test('GET /api/planet missing params returns 400', async (t) => {
+  const server = app.listen(0);
+  t.after(() => server.close());
+  await new Promise((resolve) => server.once('listening', resolve));
+  const { port } = server.address();
+  const params = new URLSearchParams({
+    date: '2023-01-01T00:00:00Z',
+    lat: '0',
+    lon: '0'
+  });
+  const res = await fetch(`http://localhost:${port}/api/planet?${params}`);
+  assert.strictEqual(res.status, 400);
+});


### PR DESCRIPTION
## Summary
- add integration tests for `/api/planet`

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b12d4b54dc832bbac5562e7f217b66