### PR TITLE
Handle fetch errors during chart calculation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,7 +17,7 @@ export default function App() {
       setChartData(data);
     } catch (err) {
       console.error(err);
-      setError(err.message);
+      setError(err.message || 'Failed to generate chart');
     } finally {
       setLoading(false);
     }
@@ -32,7 +32,11 @@ export default function App() {
             <div className="w-16 h-16 border-4 border-orange-400 border-t-transparent rounded-full animate-spin" />
           </div>
         )}
-        {error && <p className="text-red-400">{error}</p>}
+        {error && (
+          <div role="alert" className="text-red-400">
+            {error}
+          </div>
+        )}
         {chartData && !loading && <Chart data={chartData} />}
       </div>
     </div>

--- a/src/calculateChart.js
+++ b/src/calculateChart.js
@@ -10,16 +10,20 @@ async function getAscendant(jsDate, lat, lon) {
     lon: String(lon),
   });
 
-  const res = await fetch(`/api/ascendant?${params.toString()}`);
-  if (!res.ok) {
-    let data = {};
-    try {
-      data = await res.json();
-    } catch (e) {}
-    throw new Error(data.error || res.statusText);
+  try {
+    const res = await fetch(`/api/ascendant?${params.toString()}`);
+    if (!res.ok) {
+      let data = {};
+      try {
+        data = await res.json();
+      } catch (e) {}
+      throw new Error(data.error || res.statusText);
+    }
+    const data = await res.json();
+    return data.longitude;
+  } catch (err) {
+    throw new Error(`Failed to fetch ascendant: ${err.message}`);
   }
-  const data = await res.json();
-  return data.longitude;
 }
 
 async function getPlanetPosition(jsDate, lat, lon, planet) {
@@ -30,16 +34,20 @@ async function getPlanetPosition(jsDate, lat, lon, planet) {
     planet,
   });
 
-  const res = await fetch(`/api/planet?${params.toString()}`);
-  if (!res.ok) {
-    let data = {};
-    try {
-      data = await res.json();
-    } catch (e) {}
-    throw new Error(data.error || res.statusText);
+  try {
+    const res = await fetch(`/api/planet?${params.toString()}`);
+    if (!res.ok) {
+      let data = {};
+      try {
+        data = await res.json();
+      } catch (e) {}
+      throw new Error(data.error || res.statusText);
+    }
+    const data = await res.json();
+    return data;
+  } catch (err) {
+    throw new Error(`Failed to fetch ${planet} data: ${err.message}`);
   }
-  const data = await res.json();
-  return data;
 }
 
 const PLANETS = [


### PR DESCRIPTION
## Summary
- Propagate clearer errors when ascendant or planet API requests fail
- Show inline alert in App and reset loading state on failure

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install express` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b1307fb0ac832bbfb20554a75c3763