### PR TITLE
Use Swiss Ephemeris for ascendant and strengthen API tests

### DIFF
--- a/server/index.cjs
+++ b/server/index.cjs
@@ -44,6 +44,8 @@ const PORT = process.env.PORT || 3001;
 
 // --- API Endpoints ---
 
+// Compute the ascendant directly with Swiss Ephemeris instead of
+// relying on jyotish.getAscendant.
 const computeAscendant = (date, lat, lon) => {
   const ut =
     date.getUTCHours() +

--- a/tests/api-ascendant.test.js
+++ b/tests/api-ascendant.test.js
@@ -13,6 +13,20 @@ test('GET /api/ascendant returns numeric longitude', async (t) => {
     lon: '0'
   });
   const res = await fetch(`http://localhost:${port}/api/ascendant?${params}`);
+  assert.strictEqual(res.status, 200);
   const body = await res.json();
   assert.strictEqual(typeof body.longitude, 'number');
+});
+
+test('GET /api/ascendant missing params returns 400', async (t) => {
+  const server = app.listen(0);
+  t.after(() => server.close());
+  await new Promise((resolve) => server.once('listening', resolve));
+  const { port } = server.address();
+  const params = new URLSearchParams({
+    date: '2023-01-01T00:00:00Z',
+    lat: '0'
+  });
+  const res = await fetch(`http://localhost:${port}/api/ascendant?${params}`);
+  assert.strictEqual(res.status, 400);
 });


### PR DESCRIPTION
## Summary
- document and compute ascendant directly via Swiss Ephemeris
- extend ascendant API tests with status checks and missing parameter handling

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b137fb2874832bafb583b59a1c4970