### PR TITLE
Use Swiss Ephemeris for ascendant calculation

### DIFF
--- a/tests/api-ascendant.test.js
+++ b/tests/api-ascendant.test.js
@@ -16,6 +16,8 @@ test('GET /api/ascendant returns numeric longitude', async (t) => {
   assert.strictEqual(res.status, 200);
   const body = await res.json();
   assert.strictEqual(typeof body.longitude, 'number');
+  // The ascendant should be a valid ecliptic longitude in the range [0, 360).
+  assert.ok(body.longitude >= 0 && body.longitude < 360);
 });
 
 test('GET /api/ascendant missing params returns 400', async (t) => {


### PR DESCRIPTION
## Summary
- compute ascendant longitude using Swiss Ephemeris directly
- expand API test to verify ascendant longitude is within valid range

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b13bdff3d4832bb5a10fa435d8cd0a