### PR TITLE
feat: add combined dev script

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,13 @@ A single-page React application that renders an accurate North Indian style D1 (
 npm install
 
 # Run in development
-# Start the backend in a separate terminal
-npm run server
-# Then launch the Vite dev server
-npm run dev
+# Start backend and frontend together
+npm run dev:all
 ```
 
 1. Clone this repository.
 2. Install dependencies with `npm install`.
-3. Start the backend with `npm run server` and in another terminal run `npm run dev`.
+3. Start the app with `npm run dev:all` to run the backend and Vite dev server simultaneously.
 
 ### Preparing the offline location dataset
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "server": "node server/index.cjs",
-    "test": "node --test"
+    "test": "node --test",
+    "dev:all": "concurrently \"npm run server\" \"npm run dev\""
   },
   "dependencies": {
     "express": "^4.18.2",
@@ -22,6 +23,7 @@
     "postcss": "^8.4.31",
     "tailwindcss": "^3.3.3",
     "vite": "^5.4.19",
-    "vite-plugin-node-polyfills": "^0.21.0"
+    "vite-plugin-node-polyfills": "^0.21.0",
+    "concurrently": "^8.2.2"
   }
 }


### PR DESCRIPTION
## Summary
- add `dev:all` script to run Vite and server together with `concurrently`
- document unified startup command in README

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b1432f35d0832b8a414e47db381d08