### PR TITLE
Ensure numeric degrees and handle numeric-like strings

### DIFF
--- a/src/calculateChart.js
+++ b/src/calculateChart.js
@@ -65,7 +65,9 @@ const PLANETS = [
 function longitudeToSign(longitude) {
   const sign = Math.floor(longitude / 30) + 1; // 1..12
   const degree = longitude % 30;
-  return { sign, degree: degree.toFixed(2) };
+  // Return degree as a numeric value rounded to two decimals
+  // Using unary plus converts the string result of toFixed back to a number
+  return { sign, degree: +degree.toFixed(2) };
 }
 
 export default async function calculateChart({ date, time, lat, lon }) {

--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -65,7 +65,9 @@ export default function Chart({ data, children }) {
   data.planets.forEach((p) => {
     if (!isValidNumber(p.house)) return;
 
-    const degree = isValidNumber(p.degree) ? `${p.degree}°` : 'No data';
+    // Convert degree to a number so numeric-like strings are treated as valid
+    const degreeValue = Number(p.degree);
+    const degree = isValidNumber(degreeValue) ? `${degreeValue}°` : 'No data';
 
     planetByHouse[p.house] = planetByHouse[p.house] || [];
     planetByHouse[p.house].push(


### PR DESCRIPTION
## Summary
- Return numeric degree values from `longitudeToSign`
- Allow numeric-like strings for planet degrees in `Chart`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b14e2fce48832b9e952fe245d6f678