### PR TITLE
Validate house count in chart component

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -4,7 +4,8 @@ import PropTypes from 'prop-types';
 export default function Chart({ data, children }) {
   const isValidNumber = (val) => typeof val === 'number' && !Number.isNaN(val);
 
-  const invalidHouses = !data || !Array.isArray(data.houses);
+  const invalidHouses =
+    !data || !Array.isArray(data.houses) || data.houses.length !== 12;
 
   const invalidPlanets = !data || !Array.isArray(data.planets);
 

--- a/tests/chart-render.test.js
+++ b/tests/chart-render.test.js
@@ -1,0 +1,44 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const assert = require('node:assert');
+const test = require('node:test');
+
+function loadChart() {
+  let code = fs.readFileSync(path.join(__dirname, '../src/components/Chart.jsx'), 'utf8');
+  code = code.replace("import React from 'react';", "const React = { isValidElement: () => true };");
+  code = code.replace(
+    "import PropTypes from 'prop-types';",
+    'const PropTypes = new Proxy({}, { get: () => { const fn = () => fn; fn.isRequired = fn; return fn; }});'
+  );
+  code = code.replace('export default function Chart', 'function Chart');
+  code = code.replace(
+    /if \(invalidHouses \|\| invalidPlanets\) {\n[\s\S]*?\n\s*}\n\n/,
+    'if (invalidHouses || invalidPlanets) {\n    return "Invalid chart data";\n  }\n\n'
+  );
+  code = code.replace(/if \(\n\s*children !== undefined[\s\S]*?\n\s*}\n\n/, '');
+  code = code.replace(
+    /return \([\s\S]*?\n\s*\);\n}\n\nChart.propTypes/,
+    'return "Chart";\n}\n\nChart.propTypes'
+  );
+  code += '\nmodule.exports = { default: Chart };';
+  const sandbox = { module: {}, exports: {}, require };
+  vm.runInNewContext(code, sandbox);
+  return sandbox.module.exports.default;
+}
+
+test('Chart renders only with exactly 12 houses', () => {
+  const Chart = loadChart();
+  assert.strictEqual(
+    Chart({ data: { houses: Array(12).fill(1), planets: [] } }),
+    'Chart'
+  );
+  assert.strictEqual(
+    Chart({ data: { houses: Array(11).fill(1), planets: [] } }),
+    'Invalid chart data'
+  );
+  assert.strictEqual(
+    Chart({ data: { houses: Array(13).fill(1), planets: [] } }),
+    'Invalid chart data'
+  );
+});


### PR DESCRIPTION
## Summary
- ensure chart data contains exactly twelve houses before rendering
- add unit test verifying chart rendering requires twelve houses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1541f4100832b922cdc1ad7e766f3