### PR TITLE
feat: support half-hour timezone offsets

### DIFF
--- a/src/calculateChart.js
+++ b/src/calculateChart.js
@@ -68,8 +68,8 @@ async function getTimezoneOffset(lat, lon) {
     // Ignore network or parsing errors and use fallback below
     console.error('Failed to fetch timezone offset', err);
   }
-  // Fallback: crude estimate from longitude (15° ≈ 1 hour)
-  return Math.round(lon / 15) * 60;
+  // Fallback: crude estimate from longitude with half-hour precision
+  return Math.round(lon / 7.5) * 30;
 }
 
 const PLANETS = [

--- a/tests/timezone-offset.test.js
+++ b/tests/timezone-offset.test.js
@@ -1,0 +1,42 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const assert = require('node:assert');
+const test = require('node:test');
+
+function loadGetTimezoneOffset() {
+  let code = fs.readFileSync(path.join(__dirname, '../src/calculateChart.js'), 'utf8');
+  code = code.replace(
+    'export default async function calculateChart',
+    'async function calculateChart'
+  );
+  code += '\nmodule.exports = { getTimezoneOffset };';
+  const sandbox = {
+    module: { exports: {} },
+    exports: {},
+    fetch: async () => { throw new Error('network'); },
+    console: { error: () => {} },
+  };
+  vm.runInNewContext(code, sandbox);
+  return sandbox.module.exports.getTimezoneOffset;
+}
+
+test('85°E results in UTC+5:30', async () => {
+  const getTimezoneOffset = loadGetTimezoneOffset();
+  const offset = await getTimezoneOffset(0, 85);
+  assert.strictEqual(offset, 330);
+});
+
+test('known longitudes map to expected offsets', async () => {
+  const getTimezoneOffset = loadGetTimezoneOffset();
+  const cases = [
+    { lon: 0, expected: 0 },
+    { lon: -74, expected: -300 },
+    { lon: 120, expected: 480 },
+  ];
+  for (const { lon, expected } of cases) {
+    const offset = await getTimezoneOffset(0, lon);
+    assert.strictEqual(offset, expected, `longitude ${lon}`);
+  }
+});
+


### PR DESCRIPTION
## Summary
- round longitude-based timezone offsets to nearest half hour
- add tests for getTimezoneOffset fallback

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b158be1b10832ba008cbee1037a3d0