### PR TITLE
Normalize longitude sign conversion and add tests

### DIFF
--- a/src/calculateChart.js
+++ b/src/calculateChart.js
@@ -84,7 +84,8 @@ const PLANETS = [
   { key: 'ketu', abbr: 'Ke' },
 ];
 
-function longitudeToSign(longitude) {
+export function longitudeToSign(longitude) {
+  longitude = ((longitude % 360) + 360) % 360;
   const sign = Math.floor(longitude / 30) + 1; // 1..12
   const degree = longitude % 30;
   // Return degree as a numeric value rounded to two decimals

--- a/tests/longitude-to-sign.test.js
+++ b/tests/longitude-to-sign.test.js
@@ -1,0 +1,16 @@
+const assert = require('node:assert');
+const test = require('node:test');
+
+async function getFn() {
+  return (await import('../src/calculateChart.js')).longitudeToSign;
+}
+
+test('longitudeToSign handles negative degrees', async () => {
+  const longitudeToSign = await getFn();
+  assert.deepStrictEqual(longitudeToSign(-5), { sign: 12, degree: 25 });
+});
+
+test('longitudeToSign handles degrees over 360', async () => {
+  const longitudeToSign = await getFn();
+  assert.deepStrictEqual(longitudeToSign(365), { sign: 1, degree: 5 });
+});

--- a/tests/timezone-offset.test.js
+++ b/tests/timezone-offset.test.js
@@ -7,6 +7,10 @@ const test = require('node:test');
 function loadGetTimezoneOffset() {
   let code = fs.readFileSync(path.join(__dirname, '../src/calculateChart.js'), 'utf8');
   code = code.replace(
+    'export function longitudeToSign',
+    'function longitudeToSign'
+  );
+  code = code.replace(
     'export default async function calculateChart',
     'async function calculateChart'
   );


### PR DESCRIPTION
## Summary
- Normalize longitudes to 0-360 before deriving sign and degree
- Add unit tests covering negative and >360° longitudes
- Update timezone offset test harness for new module export

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1599ceb60832b9131f9d1c725a370