### PR TITLE
Add combustion and exaltation state handling

### DIFF
--- a/src/calculateChart.js
+++ b/src/calculateChart.js
@@ -130,6 +130,8 @@ export default async function calculateChart({ date, time, lat, lon }) {
       degree: pos.degree,
       retrograde: info.retrograde,
       combust: info.combust,
+      exalted: info.exalted,
+      debilitated: info.debilitated,
       house: ((pos.sign - asc.sign + 12) % 12) + 1,
     };
   });

--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -75,7 +75,7 @@ export default function Chart({ data, children }) {
 
     planetByHouse[p.house] = planetByHouse[p.house] || [];
     planetByHouse[p.house].push(
-      `${p.abbr} ${degree}${p.retrograde ? ' R' : ''}${p.combust ? ' C' : ''}`
+      `${p.abbr} ${degree}${p.retrograde ? ' R' : ''}${p.combust ? ' C' : ''}${p.exalted ? ' E' : ''}${p.debilitated ? ' D' : ''}`
     );
   });
 
@@ -144,6 +144,8 @@ Chart.propTypes = {
           .isRequired,
         retrograde: PropTypes.bool,
         combust: PropTypes.bool,
+        exalted: PropTypes.bool,
+        debilitated: PropTypes.bool,
         house: PropTypes.number.isRequired,
         sign: PropTypes.number,
       })

--- a/tests/api-planet.test.js
+++ b/tests/api-planet.test.js
@@ -50,7 +50,7 @@ test('GET /api/planet missing params returns 400', async (t) => {
   assert.strictEqual(res.status, 400);
 });
 
-test('Ketu is always opposite Rahu with matching retrograde', async (t) => {
+  test('Ketu is always opposite Rahu with matching retrograde', async (t) => {
   const server = app.listen(0);
   t.after(() => server.close());
   await new Promise((resolve) => server.once('listening', resolve));
@@ -87,6 +87,74 @@ test('Ketu is always opposite Rahu with matching retrograde', async (t) => {
   const diff = (bodyKetu.longitude - bodyRahu.longitude + 360) % 360;
   assert.ok(Math.abs(diff - 180) < 1e-6);
   const expectedRetrograde = rahuExpected.longitudeSpeed < 0;
-  assert.strictEqual(bodyRahu.retrograde, expectedRetrograde);
-  assert.strictEqual(bodyKetu.retrograde, expectedRetrograde);
-});
+    assert.strictEqual(bodyRahu.retrograde, expectedRetrograde);
+    assert.strictEqual(bodyKetu.retrograde, expectedRetrograde);
+  });
+
+  test('combustion detection marks close planets', async (t) => {
+    const server = app.listen(0);
+    t.after(() => server.close());
+    await new Promise((resolve) => server.once('listening', resolve));
+    const { port } = server.address();
+
+    const base = { date: '2020-01-01T00:00:00Z', lat: '0', lon: '0' };
+    const paramsJupiter = new URLSearchParams({ ...base, planet: 'jupiter' });
+    const paramsMoon = new URLSearchParams({ ...base, planet: 'moon' });
+
+    const [resJupiter, resMoon] = await Promise.all([
+      fetch(`http://localhost:${port}/api/planet?${paramsJupiter}`),
+      fetch(`http://localhost:${port}/api/planet?${paramsMoon}`),
+    ]);
+
+    assert.strictEqual(resJupiter.status, 200);
+    assert.strictEqual(resMoon.status, 200);
+    const [bodyJupiter, bodyMoon] = await Promise.all([
+      resJupiter.json(),
+      resMoon.json(),
+    ]);
+
+    assert.strictEqual(bodyJupiter.combust, true);
+    assert.strictEqual(bodyMoon.combust, false);
+  });
+
+  test('exaltation and debilitation flags', async (t) => {
+    const server = app.listen(0);
+    t.after(() => server.close());
+    await new Promise((resolve) => server.once('listening', resolve));
+    const { port } = server.address();
+
+    const base = { lat: '0', lon: '0' };
+    const paramsSunEx = new URLSearchParams({
+      ...base,
+      date: '2020-05-01T00:00:00Z',
+      planet: 'sun',
+    });
+    const paramsSunDeb = new URLSearchParams({
+      ...base,
+      date: '2020-11-01T00:00:00Z',
+      planet: 'sun',
+    });
+    const paramsJupDeb = new URLSearchParams({
+      ...base,
+      date: '2020-08-01T00:00:00Z',
+      planet: 'jupiter',
+    });
+
+    const [resEx, resDeb, resJupDeb] = await Promise.all([
+      fetch(`http://localhost:${port}/api/planet?${paramsSunEx}`),
+      fetch(`http://localhost:${port}/api/planet?${paramsSunDeb}`),
+      fetch(`http://localhost:${port}/api/planet?${paramsJupDeb}`),
+    ]);
+
+    const [bodyEx, bodyDeb, bodyJupDeb] = await Promise.all([
+      resEx.json(),
+      resDeb.json(),
+      resJupDeb.json(),
+    ]);
+
+    assert.strictEqual(bodyEx.exalted, true);
+    assert.strictEqual(bodyEx.debilitated, false);
+    assert.strictEqual(bodyDeb.debilitated, true);
+    assert.strictEqual(bodyDeb.exalted, false);
+    assert.strictEqual(bodyJupDeb.debilitated, true);
+  });


### PR DESCRIPTION
## Summary
- compute Sun longitude once and mark planets combust using per-planet thresholds
- map exaltation/debilitation signs and expose flags in API
- surface new states in chart calculations and rendering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1671dcc30832bb3d7292cf70794e9