### PR TITLE
Ensure houses follow natural zodiac order

### DIFF
--- a/src/calculateChart.js
+++ b/src/calculateChart.js
@@ -108,7 +108,23 @@ export default async function calculateChart({ date, time, lat, lon }) {
   const ascLong = await getAscendant(jsDate, lat, lon);
   const asc = longitudeToSign(ascLong);
 
-  const houses = Array.from({ length: 12 }, (_, i) => ((asc.sign + i - 1) % 12) + 1);
+  const houses = Array.from(
+    { length: 12 },
+    (_, i) => ((asc.sign + i - 1) % 12) + 1
+  );
+
+  // Sanity check: ensure we ended up with a full 12-sign progression
+  // starting from the ascendant. This helps catch logic errors if the
+  // calculation above is ever altered.
+  const expected = Array.from(
+    { length: 12 },
+    (_, i) => ((asc.sign + i - 1) % 12) + 1
+  );
+  const validHouses =
+    houses.length === 12 && houses.every((h, idx) => h === expected[idx]);
+  if (!validHouses) {
+    throw new Error('Invalid house sequence');
+  }
 
   // Planetary calculations
   let planetData;

--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -5,7 +5,13 @@ export default function Chart({ data, children }) {
   const isValidNumber = (val) => typeof val === 'number' && !Number.isNaN(val);
 
   const invalidHouses =
-    !data || !Array.isArray(data.houses) || data.houses.length !== 12;
+    !data ||
+    !Array.isArray(data.houses) ||
+    data.houses.length !== 12 ||
+    !data.houses.every(
+      (h, idx, arr) =>
+        typeof h === 'number' && h === ((arr[0] + idx - 1) % 12) + 1
+    );
 
   const invalidPlanets = !data || !Array.isArray(data.planets);
 

--- a/tests/chart-render.test.js
+++ b/tests/chart-render.test.js
@@ -27,10 +27,11 @@ function loadChart() {
   return sandbox.module.exports.default;
 }
 
-test('Chart renders only with exactly 12 houses', () => {
+test('Chart renders only with exactly 12 houses in natural order', () => {
   const Chart = loadChart();
+  const natural = Array.from({ length: 12 }, (_, i) => i + 1);
   assert.strictEqual(
-    Chart({ data: { houses: Array(12).fill(1), planets: [] } }),
+    Chart({ data: { houses: natural, planets: [] } }),
     'Chart'
   );
   assert.strictEqual(
@@ -39,6 +40,11 @@ test('Chart renders only with exactly 12 houses', () => {
   );
   assert.strictEqual(
     Chart({ data: { houses: Array(13).fill(1), planets: [] } }),
+    'Invalid chart data'
+  );
+  // Misordered houses should also be rejected
+  assert.strictEqual(
+    Chart({ data: { houses: [1, 2, 4, 3, 5, 6, 7, 8, 9, 10, 11, 12], planets: [] } }),
     'Invalid chart data'
   );
 });

--- a/tests/houses-order.test.js
+++ b/tests/houses-order.test.js
@@ -1,0 +1,31 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+// Ensure calculateChart yields a natural zodiac sequence of houses
+// starting from the ascendant sign.
+test('calculateChart produces houses in natural zodiac order', async () => {
+  const calculateChart = (await import('../src/calculateChart.js')).default;
+
+  // Stub fetch responses for timezone, ascendant, and planets
+  global.fetch = async (url) => {
+    if (url.startsWith('https://www.timeapi.io')) {
+      return { ok: true, json: async () => ({ currentUtcOffset: { hours: 0, minutes: 0 } }) };
+    }
+    if (url.startsWith('/api/ascendant')) {
+      return { ok: true, json: async () => ({ longitude: 90 }) };
+    }
+    if (url.startsWith('/api/planet')) {
+      return { ok: true, json: async () => ({ longitude: 0 }) };
+    }
+    throw new Error('Unexpected URL ' + url);
+  };
+
+  const data = await calculateChart({
+    date: '2020-01-01',
+    time: '12:00',
+    lat: 0,
+    lon: 0,
+  });
+
+  assert.deepStrictEqual(data.houses, [4,5,6,7,8,9,10,11,12,1,2,3]);
+});


### PR DESCRIPTION
## Summary
- Validate `calculateChart` produces a 12-sign progression starting from ascendant
- Enforce natural zodiac order for houses in `Chart` component
- Add tests verifying correct house order and rendering safeguards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b16d41c87c832b9f91767d6da952bf