### PR TITLE
Render chart with fixed sign rhombi

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -1,6 +1,52 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+const VIEWBOX_SIZE = 100;
+const GRID = 4;
+const BOX_SIZE = (VIEWBOX_SIZE / GRID) / 2; // half a grid unit
+
+// Fixed positions for the 12 zodiac signs (Aries at the top, proceeding
+// counter-clockwise). Values represent grid coordinates on a 4x4 grid.
+const positions = {
+  1: { x: 2, y: 0.5 }, // Aries - top centre
+  2: { x: 3.5, y: 1.5 }, // Taurus - top right
+  3: { x: 3.5, y: 2.5 }, // Gemini - right
+  4: { x: 2.5, y: 3.5 }, // Cancer - bottom right
+  5: { x: 2, y: 3.5 }, // Leo - bottom centre
+  6: { x: 0.5, y: 2.5 }, // Virgo - bottom left
+  7: { x: 0.5, y: 1.5 }, // Libra - left
+  8: { x: 1.5, y: 0.5 }, // Scorpio - top left
+  9: { x: 1.5, y: 1.5 }, // Sagittarius - inner top-left
+  10: { x: 2.5, y: 1.5 }, // Capricorn - inner top-right
+  11: { x: 2.5, y: 2.5 }, // Aquarius - inner bottom-right
+  12: { x: 1.5, y: 2.5 }, // Pisces - inner bottom-left
+};
+
+// Pre-computed polygon information for each sign box (rhombus).
+const SIGN_BOXES = Array.from({ length: 12 }, (_, i) => {
+  const sign = i + 1;
+  const pos = positions[sign];
+  const cx = (pos.x / GRID) * VIEWBOX_SIZE;
+  const cy = (pos.y / GRID) * VIEWBOX_SIZE;
+  const points = `${cx},${cy - BOX_SIZE} ${cx + BOX_SIZE},${cy} ${cx},${cy + BOX_SIZE} ${cx - BOX_SIZE},${cy}`;
+  return { sign, cx, cy, points };
+});
+
+const SIGN_MAP = {
+  1: { abbr: 'Ar', symbol: '\u2648', name: 'Aries' },
+  2: { abbr: 'Ta', symbol: '\u2649', name: 'Taurus' },
+  3: { abbr: 'Ge', symbol: '\u264A', name: 'Gemini' },
+  4: { abbr: 'Cn', symbol: '\u264B', name: 'Cancer' },
+  5: { abbr: 'Le', symbol: '\u264C', name: 'Leo' },
+  6: { abbr: 'Vi', symbol: '\u264D', name: 'Virgo' },
+  7: { abbr: 'Li', symbol: '\u264E', name: 'Libra' },
+  8: { abbr: 'Sc', symbol: '\u264F', name: 'Scorpio' },
+  9: { abbr: 'Sg', symbol: '\u2650', name: 'Sagittarius' },
+  10: { abbr: 'Cp', symbol: '\u2651', name: 'Capricorn' },
+  11: { abbr: 'Aq', symbol: '\u2652', name: 'Aquarius' },
+  12: { abbr: 'Pi', symbol: '\u2653', name: 'Pisces' },
+};
+
 export default function Chart({ data, children }) {
   const isValidNumber = (val) => typeof val === 'number' && !Number.isNaN(val);
 
@@ -38,55 +84,22 @@ export default function Chart({ data, children }) {
     );
   }
 
-  // Coordinates for the 12 houses laid out on a 4x4 grid. Values represent
-  // the centre point of each house in grid units so we can position labels
-  // without drawing individual boxes.
-  const positions = {
-    1: { x: 2, y: 0.5 }, // top centre
-    2: { x: 3.5, y: 1.5 }, // top right
-    3: { x: 3.5, y: 2.5 }, // right
-    4: { x: 2.5, y: 3.5 }, // bottom right
-    5: { x: 2, y: 3.5 }, // bottom centre
-    6: { x: 0.5, y: 2.5 }, // bottom left
-    7: { x: 0.5, y: 1.5 }, // left
-    8: { x: 1.5, y: 0.5 }, // top left
-    9: { x: 1.5, y: 1.5 }, // inner top-left
-    10: { x: 2.5, y: 1.5 }, // inner top-right
-    11: { x: 2.5, y: 2.5 }, // inner bottom-right
-    12: { x: 1.5, y: 2.5 }, // inner bottom-left
-  };
-
-  const SIGN_MAP = {
-    1: { abbr: 'Ar', symbol: '\u2648', name: 'Aries' },
-    2: { abbr: 'Ta', symbol: '\u2649', name: 'Taurus' },
-    3: { abbr: 'Ge', symbol: '\u264A', name: 'Gemini' },
-    4: { abbr: 'Cn', symbol: '\u264B', name: 'Cancer' },
-    5: { abbr: 'Le', symbol: '\u264C', name: 'Leo' },
-    6: { abbr: 'Vi', symbol: '\u264D', name: 'Virgo' },
-    7: { abbr: 'Li', symbol: '\u264E', name: 'Libra' },
-    8: { abbr: 'Sc', symbol: '\u264F', name: 'Scorpio' },
-    9: { abbr: 'Sg', symbol: '\u2650', name: 'Sagittarius' },
-    10: { abbr: 'Cp', symbol: '\u2651', name: 'Capricorn' },
-    11: { abbr: 'Aq', symbol: '\u2652', name: 'Aquarius' },
-    12: { abbr: 'Pi', symbol: '\u2653', name: 'Pisces' },
-  };
-
-  const planetByHouse = {};
+  const planetBySign = {};
   data.planets.forEach((p) => {
-    if (!isValidNumber(p.house)) return;
+    if (!isValidNumber(p.sign)) return;
 
     // Convert degree to a number so numeric-like strings are treated as valid
     const degreeValue = Number(p.degree);
     const degree = isValidNumber(degreeValue) ? `${degreeValue}°` : 'No data';
 
-    planetByHouse[p.house] = planetByHouse[p.house] || [];
-    planetByHouse[p.house].push(
+    planetBySign[p.sign] = planetBySign[p.sign] || [];
+    planetBySign[p.sign].push(
       `${p.abbr} ${degree}${p.retrograde ? ' R' : ''}${p.combust ? ' C' : ''}${p.exalted ? ' E' : ''}${p.debilitated ? ' D' : ''}`
     );
   });
 
+  const ascSign = data.houses[0];
   const size = 300; // chart size
-  const grid = 4; // 4x4 grid for positioning
 
   return (
     <div className="backdrop-blur-md bg-white/5 border border-white/10 rounded-xl p-6 flex items-center justify-center">
@@ -97,40 +110,33 @@ export default function Chart({ data, children }) {
           fill="none"
           stroke="currentColor"
         >
-          <polygon
-            points="50,0 100,50 50,100 0,50"
-            strokeWidth="2"
-          />
-          <line x1="50" y1="0" x2="50" y2="100" strokeWidth="1" />
-          <line x1="0" y1="50" x2="100" y2="50" strokeWidth="1" />
-          <line x1="25" y1="25" x2="75" y2="75" strokeWidth="1" />
-          <line x1="75" y1="25" x2="25" y2="75" strokeWidth="1" />
-          <polygon
-            points="50,25 75,50 50,75 25,50"
-            strokeWidth="1"
-          />
+          <polygon points="50,0 100,50 50,100 0,50" strokeWidth="2" />
+          {SIGN_BOXES.map((box) => (
+            <polygon key={box.sign} points={box.points} strokeWidth="1" />
+          ))}
         </svg>
-        {Array.from({ length: 12 }, (_, i) => i + 1).map((house) => {
-          const pos = positions[house];
-          const signNum = data.houses[house - 1];
-          const signInfo = SIGN_MAP[signNum] || {};
+        {SIGN_BOXES.map((box) => {
+          const signInfo = SIGN_MAP[box.sign] || {};
 
           return (
             <div
-              key={house}
+              key={box.sign}
               className="absolute flex flex-col items-center text-xs gap-1"
               style={{
-                top: (pos.y / grid) * 100 + '%',
-                left: (pos.x / grid) * 100 + '%',
+                top: `${box.cy}%`,
+                left: `${box.cx}%`,
                 transform: 'translate(-50%, -50%)',
               }}
             >
-              <span className="text-yellow-300 font-semibold">{signNum}</span>
+              <span className="text-yellow-300 font-semibold">
+                {box.sign}
+                {box.sign === ascSign ? ' Asc' : ''}
+              </span>
               <span className="text-orange-300 font-semibold flex items-center gap-1">
                 {signInfo.symbol} {signInfo.abbr} {signInfo.name || ''}
               </span>
-              {planetByHouse[house] &&
-                planetByHouse[house].map((pl, idx) => <span key={idx}>{pl}</span>)}
+              {planetBySign[box.sign] &&
+                planetBySign[box.sign].map((pl, idx) => <span key={idx}>{pl}</span>)}
             </div>
           );
         })}
@@ -159,3 +165,4 @@ Chart.propTypes = {
   }).isRequired,
   children: PropTypes.node,
 };
+

--- a/tests/chart-render.test.js
+++ b/tests/chart-render.test.js
@@ -21,14 +21,14 @@ function loadChart() {
     /return \([\s\S]*?\n\s*\);\n}\n\nChart.propTypes/,
     'return "Chart";\n}\n\nChart.propTypes'
   );
-  code += '\nmodule.exports = { default: Chart };';
+  code += '\nmodule.exports = { default: Chart, SIGN_BOXES };';
   const sandbox = { module: {}, exports: {}, require };
   vm.runInNewContext(code, sandbox);
-  return sandbox.module.exports.default;
+  return sandbox.module.exports;
 }
 
 test('Chart renders only with exactly 12 houses in natural order', () => {
-  const Chart = loadChart();
+  const { default: Chart } = loadChart();
   const natural = Array.from({ length: 12 }, (_, i) => i + 1);
   assert.strictEqual(
     Chart({ data: { houses: natural, planets: [] } }),
@@ -49,10 +49,13 @@ test('Chart renders only with exactly 12 houses in natural order', () => {
   );
 });
 
-test('Chart SVG includes inner polygon to separate houses', () => {
+test('Chart SVG uses 12 rhombi with no inner polygon', () => {
+  const { SIGN_BOXES } = loadChart();
+  assert.strictEqual(SIGN_BOXES.length, 12);
   const code = fs.readFileSync(
     path.join(__dirname, '../src/components/Chart.jsx'),
     'utf8'
   );
-  assert.ok(code.includes('points="50,25 75,50 50,75 25,50"'));
+  assert.ok(!code.includes('<line'));
+  assert.ok(!code.includes('50,25 75,50 50,75 25,50'));
 });


### PR DESCRIPTION
## Summary
- Replace line-drawn chart with precomputed rhombus polygons
- Fix sign positions to standard zodiac order and mark ascendant
- Update chart render test to expect 12 rhombi without inner polygon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b17ffe39f0832b9339151aee23df2f