### PR TITLE
feat: add locale-aware datetime inputs

### DIFF
--- a/src/components/BirthForm.jsx
+++ b/src/components/BirthForm.jsx
@@ -1,11 +1,14 @@
 import { useState, useEffect } from 'react';
 import { searchPlaces } from '../lib/offlineGeocoder';
+import { parseDateInput, parseTimeInput, monthFirst } from '../lib/parseDateTime';
 
 export default function BirthForm({ onSubmit, loading }) {
+  const locale = navigator.language || 'en-US';
   const [form, setForm] = useState({
     name: '',
-    date: '',
-    time: '',
+    dateInput: '',
+    timeInput: '',
+    ampm: 'AM',
     place: '',
     lat: null,
     lon: null,
@@ -40,12 +43,26 @@ export default function BirthForm({ onSubmit, loading }) {
     setForm({ ...form, [e.target.name]: e.target.value });
   };
 
-  const valid = form.name && form.date && form.time && form.lat !== null && form.lon !== null;
+  const parsedDate = parseDateInput(form.dateInput, locale);
+  const parsedTime = parseTimeInput(form.timeInput, form.ampm);
+  const iso = parsedDate && parsedTime ? `${parsedDate}T${parsedTime}` : '';
+  const dateError = form.dateInput && !parsedDate ? 'Invalid date' : '';
+  const timeError = form.timeInput && !parsedTime ? 'Invalid time' : '';
+
+  const valid =
+    form.name && parsedDate && parsedTime && form.lat !== null && form.lon !== null;
 
   const submit = (e) => {
     e.preventDefault();
     if (!valid) return;
-    onSubmit(form);
+    onSubmit({
+      name: form.name,
+      date: parsedDate,
+      time: parsedTime,
+      place: form.place,
+      lat: form.lat,
+      lon: form.lon,
+    });
   };
 
   const buttonClasses = [
@@ -80,26 +97,52 @@ export default function BirthForm({ onSubmit, loading }) {
         <div>
           <label className="block mb-1">Date of Birth</label>
           <input
-            type="date"
-            name="date"
-            value={form.date}
+            type="text"
+            name="dateInput"
+            placeholder={monthFirst(locale) ? 'MM-DD-YYYY' : 'DD-MM-YYYY'}
+            value={form.dateInput}
             onChange={handleChange}
             className="w-full p-2 rounded bg-slate-800 border border-slate-700"
             required
           />
+          {dateError && <p className="text-red-400 text-sm mt-1">{dateError}</p>}
         </div>
         <div>
           <label className="block mb-1">Time of Birth</label>
-          <input
-            type="time"
-            name="time"
-            value={form.time}
-            onChange={handleChange}
-            className="w-full p-2 rounded bg-slate-800 border border-slate-700"
-            required
-          />
+          <div className="flex gap-2">
+            <input
+              type="text"
+              name="timeInput"
+              placeholder="HH:MM"
+              value={form.timeInput}
+              onChange={handleChange}
+              className="w-full p-2 rounded bg-slate-800 border border-slate-700"
+              required
+            />
+            <select
+              name="ampm"
+              value={form.ampm}
+              onChange={handleChange}
+              className="p-2 rounded bg-slate-800 border border-slate-700"
+            >
+              <option value="AM">AM</option>
+              <option value="PM">PM</option>
+            </select>
+          </div>
+          {timeError && <p className="text-red-400 text-sm mt-1">{timeError}</p>}
         </div>
       </div>
+      {iso && (
+        <div>
+          <label className="block mb-1">Resolved Date-Time (ISO)</label>
+          <input
+            type="text"
+            value={iso}
+            readOnly
+            className="w-full p-2 rounded bg-slate-800 border border-slate-700"
+          />
+        </div>
+      )}
       <div className="relative">
         <label className="block mb-1">Place of Birth</label>
         <input

--- a/src/lib/parseDateTime.js
+++ b/src/lib/parseDateTime.js
@@ -1,0 +1,53 @@
+export function monthFirst(locale = 'en-US') {
+  const parts = new Intl.DateTimeFormat(locale).formatToParts(new Date(2020, 11, 31));
+  const idxMonth = parts.findIndex((p) => p.type === 'month');
+  const idxDay = parts.findIndex((p) => p.type === 'day');
+  return idxMonth < idxDay;
+}
+
+export function parseDateInput(input, locale = 'en-US') {
+  if (!input) return null;
+  const parts = input.trim().split(/[-/]/).map(Number);
+  if (parts.length !== 3 || parts.some(Number.isNaN)) return null;
+  const [a, b, c] = parts;
+  const monthFirstOrder = monthFirst(locale);
+  const day = monthFirstOrder ? b : a;
+  const month = monthFirstOrder ? a : b;
+  const year = c;
+  const date = new Date(Date.UTC(year, month - 1, day));
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() + 1 !== month ||
+    date.getUTCDate() !== day
+  ) {
+    return null;
+  }
+  const mm = String(month).padStart(2, '0');
+  const dd = String(day).padStart(2, '0');
+  return `${year}-${mm}-${dd}`;
+}
+
+export function parseTimeInput(input, ampm = 'AM') {
+  if (!input) return null;
+  const parts = input.trim().split(':').map(Number);
+  if (parts.length !== 2 || parts.some(Number.isNaN)) return null;
+  let [hour, minute] = parts;
+  if (hour < 1 || hour > 12 || minute < 0 || minute > 59) return null;
+  hour = hour % 12;
+  if (ampm === 'PM') hour += 12;
+  const hh = String(hour).padStart(2, '0');
+  const mm = String(minute).padStart(2, '0');
+  return `${hh}:${mm}`;
+}
+
+export function formatTime24To12(time24) {
+  const parts = time24.split(':').map(Number);
+  if (parts.length !== 2 || parts.some(Number.isNaN)) return { time: '', ampm: 'AM' };
+  let [hour, minute] = parts;
+  const ampm = hour >= 12 ? 'PM' : 'AM';
+  hour = hour % 12;
+  if (hour === 0) hour = 12;
+  const hh = String(hour);
+  const mm = String(minute).padStart(2, '0');
+  return { time: `${hh}:${mm}`, ampm };
+}

--- a/tests/datetime-parse.test.js
+++ b/tests/datetime-parse.test.js
@@ -1,0 +1,25 @@
+const test = require('node:test');
+const assert = require('node:assert');
+
+function load() {
+  return import('../src/lib/parseDateTime.js');
+}
+
+test('parses ambiguous dates by locale', async () => {
+  const { parseDateInput } = await load();
+  assert.strictEqual(parseDateInput('03-04-2023', 'en-US'), '2023-03-04');
+  assert.strictEqual(parseDateInput('03-04-2023', 'en-GB'), '2023-04-03');
+});
+
+test('converts 12-hour time and preserves AM/PM', async () => {
+  const { parseTimeInput, formatTime24To12 } = await load();
+  const am = parseTimeInput('12:30', 'AM');
+  const backAm = formatTime24To12(am);
+  assert.strictEqual(am, '00:30');
+  assert.deepStrictEqual(backAm, { time: '12:30', ampm: 'AM' });
+
+  const pm = parseTimeInput('3:15', 'PM');
+  const backPm = formatTime24To12(pm);
+  assert.strictEqual(pm, '15:15');
+  assert.deepStrictEqual(backPm, { time: '3:15', ampm: 'PM' });
+});


### PR DESCRIPTION
## Summary
- replace native date/time inputs with text fields using locale-aware parsing
- add AM/PM toggle and show resolved ISO timestamp
- cover ambiguous dates and AM/PM persistence with tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b184ac3374832b9b0db69ba9844114