### PR TITLE
Refactor chart layout and labeling

### DIFF
--- a/tests/chart-render.test.js
+++ b/tests/chart-render.test.js
@@ -21,7 +21,7 @@ function loadChart() {
     /return \([\s\S]*?\n\s*\);\n}\n\nChart.propTypes/,
     'return "Chart";\n}\n\nChart.propTypes'
   );
-  code += '\nmodule.exports = { default: Chart, SIGN_BOXES };';
+  code += '\nmodule.exports = { default: Chart, SIGN_BOX_CENTERS, BOX_SIZE, diamondPath };';
   const sandbox = { module: {}, exports: {}, require };
   vm.runInNewContext(code, sandbox);
   return sandbox.module.exports;
@@ -50,9 +50,10 @@ test('Chart renders only with exactly 12 houses in natural order', () => {
 });
 
 test('Chart SVG uses 12 distinct rhombi with no central cross', () => {
-  const { SIGN_BOXES } = loadChart();
-  assert.strictEqual(SIGN_BOXES.length, 12);
-  const unique = new Set(SIGN_BOXES.map((b) => b.points));
+  const { SIGN_BOX_CENTERS, BOX_SIZE, diamondPath } = loadChart();
+  assert.strictEqual(SIGN_BOX_CENTERS.length, 12);
+  const paths = SIGN_BOX_CENTERS.map((c) => diamondPath(c.cx, c.cy, BOX_SIZE));
+  const unique = new Set(paths);
   assert.strictEqual(unique.size, 12);
   const code = fs.readFileSync(
     path.join(__dirname, '../src/components/Chart.jsx'),
@@ -66,28 +67,28 @@ test('Planet labels are centred within sign boxes', () => {
     path.join(__dirname, '../src/components/Chart.jsx'),
     'utf8'
   );
-  assert.ok(code.includes("top: `${box.cy}%`"));
-  assert.ok(code.includes("left: `${box.cx}%`"));
+  assert.ok(code.includes("top: `${c.cy}%`"));
+  assert.ok(code.includes("left: `${c.cx}%`"));
   assert.ok(code.includes("transform: 'translate(-50%, -50%)'"));
-  assert.ok(code.includes('planetBySign[box.sign] &&'));
+  assert.ok(code.includes('planetBySign[sign] &&'));
 });
 
 test('Rhombi positions follow canonical North-Indian layout', () => {
-  const { SIGN_BOXES } = loadChart();
+  const { SIGN_BOX_CENTERS } = loadChart();
   const expected = [
-    '50,0 62.5,12.5 50,25 37.5,12.5',
-    '87.5,25 100,37.5 87.5,50 75,37.5',
-    '87.5,50 100,62.5 87.5,75 75,62.5',
-    '62.5,75 75,87.5 62.5,100 50,87.5',
-    '50,75 62.5,87.5 50,100 37.5,87.5',
-    '12.5,50 25,62.5 12.5,75 0,62.5',
-    '12.5,25 25,37.5 12.5,50 0,37.5',
-    '37.5,0 50,12.5 37.5,25 25,12.5',
-    '37.5,25 50,37.5 37.5,50 25,37.5',
-    '62.5,25 75,37.5 62.5,50 50,37.5',
-    '62.5,50 75,62.5 62.5,75 50,62.5',
-    '37.5,50 50,62.5 37.5,75 25,62.5',
+    [50, 12.5],
+    [87.5, 37.5],
+    [87.5, 62.5],
+    [62.5, 87.5],
+    [50, 87.5],
+    [12.5, 62.5],
+    [12.5, 37.5],
+    [37.5, 12.5],
+    [37.5, 37.5],
+    [62.5, 37.5],
+    [62.5, 62.5],
+    [37.5, 62.5],
   ];
-  const points = Array.from(SIGN_BOXES, (b) => b.points);
-  assert.deepStrictEqual(points, expected);
+  const coords = SIGN_BOX_CENTERS.map((c) => [c.cx, c.cy]);
+  assert.strictEqual(JSON.stringify(coords), JSON.stringify(expected));
 });


### PR DESCRIPTION
## Summary
- use `SIGN_BOX_CENTERS` with a single `BOX_SIZE`
- draw rhombi via `diamondPath` and map signs clockwise
- show sign abbreviations, rotated house numbers and ascendant marker
- stack planet labels vertically with R/C flags

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1a1c08cbc832b997f8fd88d08f526