### PR TITLE
Add timezone selection and strict date/time parsing

### DIFF
--- a/src/calculateChart.js
+++ b/src/calculateChart.js
@@ -44,12 +44,14 @@ export function longitudeToSign(longitude) {
   return { sign, degree: +degree.toFixed(2) };
 }
 
-export default async function calculateChart({ date, time, lat, lon }) {
-  let tz;
-  try {
-    tz = getTimezoneName(lat, lon);
-  } catch {
-    tz = 'UTC';
+export default async function calculateChart({ date, time, lat, lon, timezone }) {
+  let tz = timezone;
+  if (!tz) {
+    try {
+      tz = getTimezoneName(lat, lon);
+    } catch {
+      tz = 'UTC';
+    }
   }
   const params = new URLSearchParams({
     datetime: `${date}T${time}`,

--- a/tests/datetime-parse.test.js
+++ b/tests/datetime-parse.test.js
@@ -23,3 +23,9 @@ test('converts 12-hour time and preserves AM/PM', async () => {
   assert.strictEqual(pm, '15:15');
   assert.deepStrictEqual(backPm, { time: '3:15', ampm: 'PM' });
 });
+
+test('rejects invalid date and time', async () => {
+  const { parseDateInput, parseTimeInput } = await load();
+  assert.strictEqual(parseDateInput('31-02-2023', 'en-GB'), null);
+  assert.strictEqual(parseTimeInput('13:00', 'AM'), null);
+});


### PR DESCRIPTION
## Summary
- use Luxon for locale-specific `dd-MM-yyyy`/`MM-dd-yyyy` parsing and strict AM/PM time conversion
- add timezone selector (default `Asia/Kolkata`) and show resolved ISO datetime with offset
- allow overriding timezone in chart calculation
- test invalid date and time rejection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1a3211060832ba54e26b4ff457273