### PR TITLE
Expose house mapping and verify lunar node separation

### DIFF
--- a/src/calculateChart.js
+++ b/src/calculateChart.js
@@ -61,7 +61,7 @@ export default async function calculateChart({ date, time, lat, lon, timezone })
   const { ascSign, houses, planets: rawPlanets } = computePositions(dtISO, lat, lon);
 
   const planets = (rawPlanets || []).map((p) => {
-    const house = ((p.sign - ascSign + 12) % 12) + 1;
+    const house = houses[p.sign];
     const abbr = PLANETS.find((pl) => pl.key === p.name)?.abbr;
     return {
       name: p.name,

--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -45,11 +45,16 @@ export default function Chart({ data, children }) {
   const invalidHouses =
     !data ||
     !Array.isArray(data.houses) ||
-    data.houses.length !== 12 ||
-    !data.houses.every(
-      (h, idx, arr) =>
-        typeof h === 'number' && h === ((arr[0] + idx - 1) % 12) + 1
-    );
+    data.houses.length !== 13 ||
+    (() => {
+      const asc = data.houses.indexOf(1);
+      if (asc === -1) return true;
+      for (let i = 0; i < 12; i++) {
+        const sign = ((asc - 1 + i) % 12) + 1;
+        if (data.houses[sign] !== i + 1) return true;
+      }
+      return false;
+    })();
 
   const invalidPlanets = !data || !Array.isArray(data.planets);
 
@@ -94,7 +99,7 @@ export default function Chart({ data, children }) {
     );
   });
 
-  const ascSign = data.houses[0];
+  const ascSign = data.ascendant?.sign || data.houses.indexOf(1);
   const size = 300; // chart size
 
   return (
@@ -113,7 +118,7 @@ export default function Chart({ data, children }) {
         </svg>
         {SIGN_BOX_CENTERS.map((c, idx) => {
           const sign = idx + 1;
-          const houseNum = ((sign - ascSign + 12) % 12) + 1;
+          const houseNum = data.houses[sign];
 
           return (
             <div

--- a/tests/chart-orientation.test.js
+++ b/tests/chart-orientation.test.js
@@ -33,7 +33,7 @@ test('calculateChart assigns Libra ascendant to first house', async (t) => {
     lon: 0,
   });
 
-  assert.strictEqual(chart.houses[0], 7);
+  assert.strictEqual(chart.houses[7], 1);
   const sun = chart.planets.find((p) => p.name === 'sun');
   assert.strictEqual(sun.sign, 7);
   assert.strictEqual(sun.house, 1);

--- a/tests/chart-render.test.js
+++ b/tests/chart-render.test.js
@@ -29,22 +29,27 @@ function loadChart() {
 
 test('Chart renders only with exactly 12 houses in natural order', () => {
   const { default: Chart } = loadChart();
-  const natural = Array.from({ length: 12 }, (_, i) => i + 1);
+  const natural = Array(13).fill(null);
+  for (let i = 1; i <= 12; i++) natural[i] = i;
   assert.strictEqual(
     Chart({ data: { houses: natural, planets: [] } }),
     'Chart'
   );
   assert.strictEqual(
-    Chart({ data: { houses: Array(11).fill(1), planets: [] } }),
+    Chart({ data: { houses: natural.slice(1), planets: [] } }),
     'Invalid chart data'
   );
+  const tooLong = Array(14).fill(null);
+  for (let i = 1; i <= 13; i++) tooLong[i] = i;
   assert.strictEqual(
-    Chart({ data: { houses: Array(13).fill(1), planets: [] } }),
+    Chart({ data: { houses: tooLong, planets: [] } }),
     'Invalid chart data'
   );
   // Misordered houses should also be rejected
+  const misordered = natural.slice();
+  [misordered[2], misordered[3]] = [3, 2];
   assert.strictEqual(
-    Chart({ data: { houses: [1, 2, 4, 3, 5, 6, 7, 8, 9, 10, 11, 12], planets: [] } }),
+    Chart({ data: { houses: misordered, planets: [] } }),
     'Invalid chart data'
   );
 });

--- a/tests/ephemeris.test.js
+++ b/tests/ephemeris.test.js
@@ -38,17 +38,21 @@ test('sign to house mapping and retrograde flags', async () => {
     },
   };
 
-  const result = compute_positions({ datetime: '2020-01-01T00:00', tz: 'UTC', lat: 0, lon: 0 }, fakeSwe);
+  const result = compute_positions(
+    { datetime: '2020-01-01T00:00', tz: 'UTC', lat: 0, lon: 0 },
+    fakeSwe
+  );
 
-  assert.strictEqual(result.asc_sign, 5); // Leo ascendant
+  assert.strictEqual(result.ascSign, 5); // Leo ascendant
   const planets = Object.fromEntries(result.planets.map((p) => [p.name, p]));
 
   assert.strictEqual(planets.moon.sign, 8);
-  const moonHouse = ((planets.moon.sign - result.asc_sign + 12) % 12) + 1;
-  assert.strictEqual(moonHouse, 4);
+  assert.strictEqual(result.houses[planets.moon.sign], 4);
   assert.strictEqual(planets.moon.retro, true);
 
   assert.strictEqual(planets.rahu.retro, true);
   assert.strictEqual(planets.ketu.sign, 8);
   assert.strictEqual(planets.ketu.retro, true);
+  const diff = (planets.ketu.sign - planets.rahu.sign + 12) % 12;
+  assert.strictEqual(diff, 6);
 });

--- a/tests/houses-order.test.js
+++ b/tests/houses-order.test.js
@@ -13,7 +13,11 @@ test('calculateChart produces houses in natural zodiac order', async () => {
     lon: 0,
   });
 
-  const start = data.houses[0];
-  const expected = Array.from({ length: 12 }, (_, i) => ((start + i - 1) % 12) + 1);
+  const asc = data.ascendant.sign;
+  const expected = Array(13).fill(null);
+  for (let i = 0; i < 12; i++) {
+    const signIndex = ((asc - 1 + i) % 12) + 1;
+    expected[signIndex] = i + 1;
+  }
   assert.deepStrictEqual(data.houses, expected);
 });

--- a/tests/reference-case.test.js
+++ b/tests/reference-case.test.js
@@ -13,7 +13,7 @@ test('reference chart matches known placements', async () => {
     lat: 26.152,
     lon: 85.897,
   });
-  assert.strictEqual(res.asc_sign, 1);
+  assert.strictEqual(res.ascSign, 1);
   const planets = Object.fromEntries(res.planets.map((p) => [p.name, p.sign]));
   assert.strictEqual(planets.sun, 8);
   assert.strictEqual(planets.moon, 2);


### PR DESCRIPTION
## Summary
- build `houses` array mapping zodiac sign to house number and return it alongside `ascSign` and planets
- validate Rahu and Ketu remain six signs apart and surface error otherwise
- update chart calculations and components to consume new house mapping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1a68f1ed4832b8c7ded1cb996cfe7