### PR TITLE
fix: use namespace import for swisseph

### DIFF
--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon';
-import swisseph from '../../swisseph-v2/index.js';
+import * as swisseph from '../../swisseph-v2/index.js';
 
 if (swisseph.swe_set_sid_mode) {
   try {


### PR DESCRIPTION
## Summary
- fix swisseph import in astro.js by using namespace import

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1a8699930832b887f310eee865201