### PR TITLE
Replace timezonefinder with geo-tz

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "timezonefinder": "^6.0.2",
+    "geo-tz": "^8.1.4",
     "jyotish-calculations": "1.0.8",
     "luxon": "^3.4.4",
     "prop-types": "^15.8.1",

--- a/src/lib/timezone.js
+++ b/src/lib/timezone.js
@@ -1,4 +1,4 @@
-let tzf;
+let geoTzModule;
 let DateTimeObj;
 
 /**
@@ -9,17 +9,17 @@ let DateTimeObj;
  * @returns {string} IANA timezone name
  */
 export function getTimezoneName(lat, lon) {
-  if (!tzf) {
-    let TF;
-    if (typeof TimezoneFinder !== 'undefined') {
-      TF = TimezoneFinder;
+  if (!geoTzModule) {
+    let mod;
+    if (typeof geoTz !== 'undefined') {
+      mod = geoTz;
     } else {
       const req = eval('require');
-      TF = req('timezonefinder');
+      mod = req('geo-tz');
     }
-    tzf = new TF();
+    geoTzModule = mod;
   }
-  const zone = tzf.timezoneAt(lat, lon);
+  const [zone] = geoTzModule.find(lat, lon);
   if (!zone) {
     throw new Error('Unable to determine time zone');
   }

--- a/tests/timezone-offset.test.js
+++ b/tests/timezone-offset.test.js
@@ -6,24 +6,23 @@ const test = require('node:test');
 
 function loadGetTimezoneOffset() {
   let code = fs.readFileSync(path.join(__dirname, '../src/lib/timezone.js'), 'utf8');
-  code = code.replace("import TimezoneFinder from 'timezonefinder';", '');
   code = code.replace("import luxon from 'luxon';", '');
   code = code.replace('const { DateTime } = luxon;', '');
   code = code.replace(/export /g, '');
   code += '\nmodule.exports = { getTimezoneOffset };';
 
-  // Stub TimezoneFinder to map coordinates used in tests to IANA zones
-  class TimezoneFinder {
-    timezoneAt(lat, lon) {
+  // Stub geo-tz to map coordinates used in tests to IANA zones
+  const geoTz = {
+    find(lat, lon) {
       if (Math.abs(lat - 40.7128) < 0.5 && Math.abs(lon + 74.0060) < 0.5) {
-        return 'America/New_York';
+        return ['America/New_York'];
       }
       if (Math.abs(lat - 55.7558) < 0.5 && Math.abs(lon - 37.6173) < 0.5) {
-        return 'Europe/Moscow';
+        return ['Europe/Moscow'];
       }
-      return null;
-    }
-  }
+      return [];
+    },
+  };
 
   // Minimal luxon DateTime stub using Intl API for historical offsets
   const DateTime = {
@@ -54,7 +53,7 @@ function loadGetTimezoneOffset() {
   const sandbox = {
     module: { exports: {} },
     exports: {},
-    TimezoneFinder,
+    geoTz,
     DateTime,
   };
   vm.runInNewContext(code, sandbox);


### PR DESCRIPTION
## Summary
- remove timezonefinder dependency and add geo-tz alternative
- refactor timezone helper to use geo-tz
- adjust timezone offset tests to stub geo-tz

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-datepicker)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1bfdb7224832b9d5769a7f9f170b5