### PR TITLE
Render chart by house

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -4,21 +4,21 @@ import PropTypes from 'prop-types';
 const VIEWBOX_SIZE = 100;
 const BOX_SIZE = VIEWBOX_SIZE / 8;
 
-// Centres for each of the 12 sign boxes, in clockwise order starting from Aries
-// at index 0. Values are percentages within the 0-100 SVG viewbox.
-const SIGN_BOX_CENTERS = [
-  { cx: 50, cy: 12.5 }, // Aries
-  { cx: 87.5, cy: 37.5 }, // Taurus
-  { cx: 87.5, cy: 62.5 }, // Gemini
-  { cx: 62.5, cy: 87.5 }, // Cancer
-  { cx: 50, cy: 87.5 }, // Leo
-  { cx: 12.5, cy: 62.5 }, // Virgo
-  { cx: 12.5, cy: 37.5 }, // Libra
-  { cx: 37.5, cy: 12.5 }, // Scorpio
-  { cx: 37.5, cy: 37.5 }, // Sagittarius
-  { cx: 62.5, cy: 37.5 }, // Capricorn
-  { cx: 62.5, cy: 62.5 }, // Aquarius
-  { cx: 37.5, cy: 62.5 }, // Pisces
+// Centres for each of the 12 house boxes, in clockwise order starting from the
+// first house at index 0. Values are percentages within the 0-100 SVG viewbox.
+const HOUSE_BOX_CENTERS = [
+  { cx: 50, cy: 12.5 }, // House 1
+  { cx: 87.5, cy: 37.5 }, // House 2
+  { cx: 87.5, cy: 62.5 }, // House 3
+  { cx: 62.5, cy: 87.5 }, // House 4
+  { cx: 50, cy: 87.5 }, // House 5
+  { cx: 12.5, cy: 62.5 }, // House 6
+  { cx: 12.5, cy: 37.5 }, // House 7
+  { cx: 37.5, cy: 12.5 }, // House 8
+  { cx: 37.5, cy: 37.5 }, // House 9
+  { cx: 62.5, cy: 37.5 }, // House 10
+  { cx: 62.5, cy: 62.5 }, // House 11
+  { cx: 37.5, cy: 62.5 }, // House 12
 ];
 
 const SIGN_LABELS = [
@@ -42,11 +42,24 @@ const diamondPath = (cx, cy, size = BOX_SIZE) =>
 export default function Chart({ data, children }) {
   const isValidNumber = (val) => typeof val === 'number' && !Number.isNaN(val);
 
+  const signByHouse = [];
   const invalidHouses =
     !data ||
     !Array.isArray(data.houses) ||
     data.houses.length !== 13 ||
     (() => {
+      for (let sign = 1; sign <= 12; sign++) {
+        const house = data.houses[sign];
+        if (
+          !isValidNumber(house) ||
+          house < 1 ||
+          house > 12 ||
+          signByHouse[house]
+        ) {
+          return true;
+        }
+        signByHouse[house] = sign;
+      }
       const asc = data.houses.indexOf(1);
       if (asc === -1) return true;
       for (let i = 0; i < 12; i++) {
@@ -81,9 +94,9 @@ export default function Chart({ data, children }) {
     );
   }
 
-  const planetBySign = {};
+  const planetByHouse = {};
   data.planets.forEach((p) => {
-    if (!isValidNumber(p.sign)) return;
+    if (!isValidNumber(p.house)) return;
 
     const degreeValue = Number(p.degree);
     let degree = 'No data';
@@ -93,13 +106,12 @@ export default function Chart({ data, children }) {
       degree = `${d}°${String(m).padStart(2, '0')}'`;
     }
 
-    planetBySign[p.sign] = planetBySign[p.sign] || [];
-    planetBySign[p.sign].push(
+    planetByHouse[p.house] = planetByHouse[p.house] || [];
+    planetByHouse[p.house].push(
       `${p.abbr} ${degree}${p.retrograde ? ' R' : ''}${p.combust ? ' C' : ''}`
     );
   });
 
-  const ascSign = data.ascendant?.sign || data.houses.indexOf(1);
   const size = 300; // chart size
 
   return (
@@ -112,17 +124,17 @@ export default function Chart({ data, children }) {
           stroke="currentColor"
         >
           <path d={diamondPath(50, 50, 50)} strokeWidth="2" />
-          {SIGN_BOX_CENTERS.map((c, idx) => (
+          {HOUSE_BOX_CENTERS.map((c, idx) => (
             <path key={idx} d={diamondPath(c.cx, c.cy)} strokeWidth="1" />
           ))}
         </svg>
-        {SIGN_BOX_CENTERS.map((c, idx) => {
-          const sign = idx + 1;
-          const houseNum = data.houses[sign];
+        {HOUSE_BOX_CENTERS.map((c, idx) => {
+          const houseNum = idx + 1;
+          const sign = signByHouse[houseNum];
 
           return (
             <div
-              key={sign}
+              key={houseNum}
               className="absolute flex flex-col items-center text-xs gap-0.5 p-1"
               style={{
                 top: `${c.cy}%`,
@@ -130,17 +142,15 @@ export default function Chart({ data, children }) {
                 transform: 'translate(-50%, -50%)',
               }}
             >
-              <span className="text-yellow-300 font-semibold">
-                {houseNum}
-              </span>
-              {sign === ascSign && (
+              <span className="text-yellow-300 font-semibold">{houseNum}</span>
+              {houseNum === 1 && (
                 <span className="text-yellow-300 text-[0.6rem] leading-none">Asc</span>
               )}
               <span className="text-orange-300 font-semibold">
-                {SIGN_LABELS[idx]}
+                {sign ? SIGN_LABELS[sign - 1] : ''}
               </span>
-              {planetBySign[sign] &&
-                planetBySign[sign].map((pl, i) => (
+              {planetByHouse[houseNum] &&
+                planetByHouse[houseNum].map((pl, i) => (
                   <span key={i}>{pl}</span>
                 ))}
             </div>

--- a/tests/chart-orientation.test.js
+++ b/tests/chart-orientation.test.js
@@ -2,7 +2,7 @@ const assert = require('node:assert');
 const test = require('node:test');
 const app = require('../server/index.cjs');
 
-test('calculateChart assigns Libra ascendant to first house', async (t) => {
+test('calculateChart assigns ascendant sign to first house for multiple charts', async (t) => {
   const server = app.listen(0);
   t.after(() => server.close());
   await new Promise((resolve) => server.once('listening', resolve));
@@ -26,15 +26,19 @@ test('calculateChart assigns Libra ascendant to first house', async (t) => {
 
   const calculateChart = (await import('../src/calculateChart.js')).default;
 
-  const chart = await calculateChart({
-    date: '2020-10-17',
-    time: '19:00',
-    lat: 0,
-    lon: 0,
-  });
+  const verify = async (params) => {
+    const chart = await calculateChart(params);
+    const asc = chart.ascendant.sign;
+    assert.strictEqual(chart.houses[asc], 1);
+    const sun = chart.planets.find((p) => p.name === 'sun');
+    assert.strictEqual(sun.house, chart.houses[sun.sign]);
+  };
 
-  assert.strictEqual(chart.houses[7], 1);
-  const sun = chart.planets.find((p) => p.name === 'sun');
-  assert.strictEqual(sun.sign, 7);
-  assert.strictEqual(sun.house, 1);
+  await t.test('Libra ascendant', () =>
+    verify({ date: '2020-10-17', time: '19:00', lat: 0, lon: 0 })
+  );
+
+  await t.test('Gemini ascendant', () =>
+    verify({ date: '2020-04-01', time: '00:00', lat: 0, lon: 0 })
+  );
 });


### PR DESCRIPTION
## Summary
- Render chart boxes by house positions rather than zodiac signs
- Invert sign-to-house mapping to house-to-sign for display and group planets by house
- Update chart tests for house-oriented layout and support multiple ascendants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1c57c08f4832b8cd28186643b6f0f