### PR TITLE
Auto-detect timezone on place selection

### DIFF
--- a/src/components/BirthForm.jsx
+++ b/src/components/BirthForm.jsx
@@ -3,6 +3,7 @@ import DatePicker from 'react-datepicker';
 import { DateTime } from 'luxon';
 import { searchPlaces } from '../lib/offlineGeocoder';
 import { parseTimeInput, monthFirst } from '../lib/parseDateTime';
+import { getTimezoneName } from '../lib/timezone.js';
 
 export default function BirthForm({ onSubmit, loading }) {
   const locale = navigator.language || 'en-US';
@@ -33,11 +34,18 @@ export default function BirthForm({ onSubmit, loading }) {
   }, [form.place]);
 
   const handleSelect = (item) => {
+    let timezone = form.timezone;
+    try {
+      timezone = getTimezoneName(item.lat, item.lon);
+    } catch (e) {
+      // fallback to manual selection if detection fails
+    }
     setForm({
       ...form,
       place: item.name,
       lat: item.lat,
       lon: item.lon,
+      timezone,
     });
     setSuggestions([]);
   };

--- a/tests/birthform-timezone.test.js
+++ b/tests/birthform-timezone.test.js
@@ -1,0 +1,41 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const assert = require('node:assert');
+const test = require('node:test');
+
+function loadHandleSelect(sandbox) {
+  const code = fs.readFileSync(path.join(__dirname, '../src/components/BirthForm.jsx'), 'utf8');
+  const match = code.match(/const handleSelect = \(item\) => {[\s\S]*?};/);
+  if (!match) throw new Error('handleSelect not found');
+  const snippet = match[0].replace('const handleSelect', 'handleSelect');
+  vm.runInNewContext(snippet, sandbox);
+  return sandbox.handleSelect;
+}
+
+test('selecting a city sets its timezone', () => {
+  const sandbox = {
+    form: {
+      name: '',
+      date: null,
+      time: null,
+      place: '',
+      lat: null,
+      lon: null,
+      timezone: 'Asia/Kolkata',
+    },
+    setForm(newForm) {
+      sandbox.form = newForm;
+    },
+    setSuggestions() {},
+    getTimezoneName(lat, lon) {
+      assert.strictEqual(lat, 40.7128);
+      assert.strictEqual(lon, -74.006);
+      return 'America/New_York';
+    },
+  };
+  const handleSelect = loadHandleSelect(sandbox);
+  const item = { name: 'New York', lat: 40.7128, lon: -74.006 };
+  handleSelect(item);
+  assert.strictEqual(sandbox.form.timezone, 'America/New_York');
+});


### PR DESCRIPTION
## Summary
- detect timezone automatically when selecting a place
- add unit test for BirthForm timezone detection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b1c7034bd8832b815ba7b6a9c5f4cd