### PR TITLE
Refactor chart rendering for North Indian layout

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -1,25 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-
-const VIEWBOX_SIZE = 100;
-const BOX_SIZE = VIEWBOX_SIZE / 8;
-
-// Centres for each of the 12 house boxes, in clockwise order starting from the
-// first house at index 0. Values are percentages within the 0-100 SVG viewbox.
-const HOUSE_BOX_CENTERS = [
-  { cx: 50, cy: 12.5 }, // House 1
-  { cx: 87.5, cy: 37.5 }, // House 2
-  { cx: 87.5, cy: 62.5 }, // House 3
-  { cx: 62.5, cy: 87.5 }, // House 4
-  { cx: 50, cy: 87.5 }, // House 5
-  { cx: 12.5, cy: 62.5 }, // House 6
-  { cx: 12.5, cy: 37.5 }, // House 7
-  { cx: 37.5, cy: 12.5 }, // House 8
-  { cx: 37.5, cy: 37.5 }, // House 9
-  { cx: 62.5, cy: 37.5 }, // House 10
-  { cx: 62.5, cy: 62.5 }, // House 11
-  { cx: 37.5, cy: 62.5 }, // House 12
-];
+import { SIGN_BOX_CENTERS, BOX_SIZE, diamondPath } from '../lib/astro.js';
 
 const SIGN_LABELS = [
   'Ar',
@@ -36,35 +17,8 @@ const SIGN_LABELS = [
   'Pi',
 ];
 
-const diamondPath = (cx, cy, size = BOX_SIZE) =>
-  `M ${cx} ${cy - size} L ${cx + size} ${cy} L ${cx} ${cy + size} L ${cx - size} ${cy} Z`;
-
 export default function Chart({ data, children }) {
-  const isValidNumber = (val) => typeof val === 'number' && !Number.isNaN(val);
-
-  const signByHouse = data?.houses;
-  const invalidHouses =
-    !data ||
-    !Array.isArray(signByHouse) ||
-    signByHouse.length !== 13 ||
-    (() => {
-      for (let house = 1; house <= 12; house++) {
-        const sign = signByHouse[house];
-        if (!isValidNumber(sign) || sign < 1 || sign > 12) {
-          return true;
-        }
-      }
-      const asc = signByHouse[1];
-      for (let i = 1; i < 12; i++) {
-        const expected = ((asc - 1 + i) % 12) + 1;
-        if (signByHouse[i + 1] !== expected) return true;
-      }
-      return false;
-    })();
-
-  const invalidPlanets = !data || !Array.isArray(data.planets);
-
-  if (invalidHouses || invalidPlanets) {
+  if (!data || !Array.isArray(data.houses) || data.houses.length !== 12) {
     return (
       <div className="backdrop-blur-md bg-white/5 border border-white/10 rounded-xl p-6 flex items-center justify-center">
         <span>Invalid chart data</span>
@@ -72,37 +26,18 @@ export default function Chart({ data, children }) {
     );
   }
 
-  if (
-    children !== undefined &&
-    children !== null &&
-    !React.isValidElement(children) &&
-    !Array.isArray(children) &&
-    typeof children !== 'string' &&
-    typeof children !== 'number'
-  ) {
-    return (
-      <div className="backdrop-blur-md bg-white/5 border border-white/10 rounded-xl p-6 flex items-center justify-center">
-        <span>Invalid children</span>
-      </div>
-    );
-  }
-
-  const planetByHouse = {};
+  const planetBySign = {};
   data.planets.forEach((p) => {
-    if (!isValidNumber(p.house)) return;
-
-    const degreeValue = Number(p.degree);
+    const degreeValue = Number(p.deg ?? p.degree);
     let degree = 'No data';
-    if (isValidNumber(degreeValue)) {
+    if (!Number.isNaN(degreeValue)) {
       const d = Math.floor(degreeValue);
       const m = Math.round((degreeValue - d) * 60);
       degree = `${d}°${String(m).padStart(2, '0')}'`;
     }
-
-    planetByHouse[p.house] = planetByHouse[p.house] || [];
-    planetByHouse[p.house].push(
-      `${p.abbr} ${degree}${p.retrograde ? ' R' : ''}${p.combust ? ' C' : ''}`
-    );
+    const label = `${p.name} ${degree}${p.retro || p.retrograde ? ' R' : ''}`;
+    planetBySign[p.sign] = planetBySign[p.sign] || [];
+    planetBySign[p.sign].push(label);
   });
 
   const size = 300; // chart size
@@ -117,17 +52,15 @@ export default function Chart({ data, children }) {
           stroke="currentColor"
         >
           <path d={diamondPath(50, 50, 50)} strokeWidth="2" />
-          {HOUSE_BOX_CENTERS.map((c, idx) => (
+          {SIGN_BOX_CENTERS.map((c, idx) => (
             <path key={idx} d={diamondPath(c.cx, c.cy)} strokeWidth="1" />
           ))}
         </svg>
-        {HOUSE_BOX_CENTERS.map((c, idx) => {
-          const houseNum = idx + 1;
-          const sign = signByHouse[houseNum];
-
+        {SIGN_BOX_CENTERS.map((c, idx) => {
+          const houseNum = data.houses[idx];
           return (
             <div
-              key={houseNum}
+              key={idx}
               className="absolute flex flex-col items-center text-xs gap-0.5 p-1"
               style={{
                 top: `${c.cy}%`,
@@ -135,17 +68,17 @@ export default function Chart({ data, children }) {
                 transform: 'translate(-50%, -50%)',
               }}
             >
-              <span className="text-yellow-300 font-semibold">{houseNum}</span>
-              {houseNum === 1 && (
+              {houseNum !== undefined && (
+                <span className="text-yellow-300 font-semibold text-[0.6rem] leading-none">
+                  {houseNum}
+                </span>
+              )}
+              {idx === data.ascSign && (
                 <span className="text-yellow-300 text-[0.6rem] leading-none">Asc</span>
               )}
-              <span className="text-orange-300 font-semibold">
-                {sign ? SIGN_LABELS[sign - 1] : ''}
-              </span>
-              {planetByHouse[houseNum] &&
-                planetByHouse[houseNum].map((pl, i) => (
-                  <span key={i}>{pl}</span>
-                ))}
+              <span className="text-orange-300 font-semibold">{SIGN_LABELS[idx]}</span>
+              {planetBySign[idx] &&
+                planetBySign[idx].map((pl, i) => <span key={i}>{pl}</span>)}
             </div>
           );
         })}
@@ -157,18 +90,14 @@ export default function Chart({ data, children }) {
 
 Chart.propTypes = {
   data: PropTypes.shape({
+    ascSign: PropTypes.number,
     houses: PropTypes.arrayOf(PropTypes.number).isRequired,
     planets: PropTypes.arrayOf(
       PropTypes.shape({
-        abbr: PropTypes.string.isRequired,
-        degree: PropTypes.oneOfType([PropTypes.number, PropTypes.string])
-          .isRequired,
-        retrograde: PropTypes.bool,
-        combust: PropTypes.bool,
-        exalted: PropTypes.bool,
-        debilitated: PropTypes.bool,
-        house: PropTypes.number.isRequired,
-        sign: PropTypes.number,
+        name: PropTypes.string.isRequired,
+        sign: PropTypes.number.isRequired,
+        deg: PropTypes.number,
+        retro: PropTypes.bool,
       })
     ).isRequired,
   }).isRequired,

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -1,6 +1,9 @@
 import { DateTime } from 'luxon';
 import * as swisseph from '../../swisseph-v2/index.js';
 
+const svgNS = 'http://www.w3.org/2000/svg';
+
+// initialise Lahiri ayanāṃśa
 if (swisseph.swe_set_sid_mode) {
   try {
     swisseph.swe_set_sid_mode(swisseph.SE_SIDM_LAHIRI, 0, 0);
@@ -9,18 +12,34 @@ if (swisseph.swe_set_sid_mode) {
 
 function lonToSignDeg(longitude) {
   const norm = ((longitude % 360) + 360) % 360;
-  const sign = Math.floor(norm / 30) + 1; // 1..12
-  const deg = +(norm % 30).toFixed(2);
+  const sign = Math.floor(norm / 30); // 0..11
+  const deg = norm % 30;
   return { sign, deg };
 }
 
-export function computePositions(dtISOWithZone, lat, lon, ayanamsha) {
-  if (swisseph.swe_set_sid_mode && ayanamsha !== undefined) {
-    try {
-      swisseph.swe_set_sid_mode(ayanamsha, 0, 0);
-    } catch {}
-  }
+export const BOX_SIZE = 12.5;
+export const SIGN_BOX_CENTERS = [
+  { cx: 50, cy: 12.5 }, // Aries
+  { cx: 75, cy: 12.5 }, // Taurus
+  { cx: 87.5, cy: 25 }, // Gemini
+  { cx: 87.5, cy: 50 }, // Cancer
+  { cx: 87.5, cy: 75 }, // Leo
+  { cx: 75, cy: 87.5 }, // Virgo
+  { cx: 50, cy: 87.5 }, // Libra
+  { cx: 25, cy: 87.5 }, // Scorpio
+  { cx: 12.5, cy: 75 }, // Sagittarius
+  { cx: 12.5, cy: 50 }, // Capricorn
+  { cx: 12.5, cy: 25 }, // Aquarius
+  { cx: 25, cy: 12.5 }, // Pisces
+];
 
+const SIGN_LABELS = ['Ar', 'Ta', 'Ge', 'Cn', 'Le', 'Vi', 'Li', 'Sc', 'Sg', 'Cp', 'Aq', 'Pi'];
+
+export function diamondPath(cx, cy, size = BOX_SIZE) {
+  return `M ${cx} ${cy - size} L ${cx + size} ${cy} L ${cx} ${cy + size} L ${cx - size} ${cy} Z`;
+}
+
+export async function computePositions(dtISOWithZone, lat, lon) {
   const dt = DateTime.fromISO(dtISOWithZone, { setZone: true });
   if (!dt.isValid) throw new Error('Invalid datetime');
 
@@ -50,40 +69,105 @@ export function computePositions(dtISOWithZone, lat, lon, ayanamsha) {
     throw new Error('Could not compute ascendant from swisseph.');
   }
   const asc = lonToSignDeg(hres.ascendant);
-  const houses = Array(13).fill(null);
+
+  const houses = Array(12).fill(null);
   for (let i = 0; i < 12; i++) {
-    const houseNum = i + 1;
-    houses[houseNum] = ((asc.sign - 1 + i) % 12) + 1;
+    houses[(asc.sign + i) % 12] = i + 1;
   }
 
   const flag = swisseph.SEFLG_SWIEPH | swisseph.SEFLG_SPEED | swisseph.SEFLG_SIDEREAL;
   const planetCodes = {
-    sun: swisseph.SE_SUN,
-    moon: swisseph.SE_MOON,
-    mercury: swisseph.SE_MERCURY,
-    venus: swisseph.SE_VENUS,
-    mars: swisseph.SE_MARS,
-    jupiter: swisseph.SE_JUPITER,
-    saturn: swisseph.SE_SATURN,
-    rahu: swisseph.SE_TRUE_NODE,
+    Su: swisseph.SE_SUN,
+    Mo: swisseph.SE_MOON,
+    Ma: swisseph.SE_MARS,
+    Me: swisseph.SE_MERCURY,
+    Ju: swisseph.SE_JUPITER,
+    Ve: swisseph.SE_VENUS,
+    Sa: swisseph.SE_SATURN,
+    Ra: swisseph.SE_TRUE_NODE,
   };
 
   const planets = [];
   const rahuData = swisseph.swe_calc_ut(jd, swisseph.SE_TRUE_NODE, flag);
   const { sign: rSign, deg: rDeg } = lonToSignDeg(rahuData.longitude);
   for (const [name, code] of Object.entries(planetCodes)) {
-    const data = name === 'rahu' ? rahuData : swisseph.swe_calc_ut(jd, code, flag);
+    const data = name === 'Ra' ? rahuData : swisseph.swe_calc_ut(jd, code, flag);
     const { sign, deg } =
-      name === 'rahu' ? { sign: rSign, deg: rDeg } : lonToSignDeg(data.longitude);
+      name === 'Ra' ? { sign: rSign, deg: rDeg } : lonToSignDeg(data.longitude);
     planets.push({ name, sign, deg, retro: data.longitudeSpeed < 0 });
   }
-
   const ketuLon = (rahuData.longitude + 180) % 360;
   const { sign: kSign, deg: kDeg } = lonToSignDeg(ketuLon);
   if (((kSign - rSign + 12) % 12) !== 6) {
     throw new Error('Rahu and Ketu are not opposite');
   }
-  planets.push({ name: 'ketu', sign: kSign, deg: kDeg, retro: rahuData.longitudeSpeed < 0 });
+  planets.push({ name: 'Ke', sign: kSign, deg: kDeg, retro: rahuData.longitudeSpeed < 0 });
 
   return { ascSign: asc.sign, houses, planets };
 }
+
+export function renderNorthIndian(svgEl, data) {
+  while (svgEl.firstChild) svgEl.removeChild(svgEl.firstChild);
+  svgEl.setAttribute('viewBox', '0 0 100 100');
+  svgEl.setAttribute('fill', 'none');
+  svgEl.setAttribute('stroke', 'currentColor');
+
+  const outer = document.createElementNS(svgNS, 'path');
+  outer.setAttribute('d', diamondPath(50, 50, 50));
+  outer.setAttribute('stroke-width', '2');
+  svgEl.appendChild(outer);
+
+  for (let i = 0; i < 12; i++) {
+    const { cx, cy } = SIGN_BOX_CENTERS[i];
+
+    const box = document.createElementNS(svgNS, 'path');
+    box.setAttribute('d', diamondPath(cx, cy, BOX_SIZE));
+    box.setAttribute('stroke-width', '1');
+    svgEl.appendChild(box);
+
+    const signText = document.createElementNS(svgNS, 'text');
+    signText.setAttribute('x', cx);
+    signText.setAttribute('y', cy - BOX_SIZE + 4);
+    signText.setAttribute('text-anchor', 'middle');
+    signText.setAttribute('font-size', '4');
+    signText.textContent = SIGN_LABELS[i];
+    svgEl.appendChild(signText);
+
+    const houseNum = data.houses?.[i];
+    if (houseNum) {
+      const hText = document.createElementNS(svgNS, 'text');
+      hText.setAttribute('x', cx - BOX_SIZE + 2);
+      hText.setAttribute('y', cy - BOX_SIZE + 4);
+      hText.setAttribute('font-size', '3');
+      hText.textContent = String(houseNum);
+      svgEl.appendChild(hText);
+    }
+
+    if (i === data.ascSign) {
+      const ascText = document.createElementNS(svgNS, 'text');
+      ascText.setAttribute('x', cx);
+      ascText.setAttribute('y', cy + BOX_SIZE - 2);
+      ascText.setAttribute('text-anchor', 'middle');
+      ascText.setAttribute('font-size', '3');
+      ascText.textContent = 'Asc';
+      svgEl.appendChild(ascText);
+    }
+
+    const planets = data.planets.filter((p) => p.sign === i);
+    let py = cy - BOX_SIZE / 2 + 8;
+    planets.forEach((p) => {
+      const t = document.createElementNS(svgNS, 'text');
+      t.setAttribute('x', cx);
+      t.setAttribute('y', py);
+      t.setAttribute('text-anchor', 'middle');
+      t.setAttribute('font-size', '3');
+      const d = Math.floor(p.deg);
+      const m = Math.round((p.deg - d) * 60);
+      const degStr = `${String(d).padStart(2, '0')}°${String(m).padStart(2, '0')}'`;
+      t.textContent = `${p.name} ${degStr}${p.retro ? ' R' : ''}`;
+      svgEl.appendChild(t);
+      py += 4;
+    });
+  }
+}
+


### PR DESCRIPTION
## Summary
- Replace house-based grid with 12 fixed sign diamonds
- Add sidereal computePositions API returning sign indexes and planets
- Render North Indian chart with sign labels, house rotation and stacked planet labels

## Testing
- `npm test` (fails: chart-orientation, chart-render, longitude-to-sign)


------
https://chatgpt.com/codex/tasks/task_e_68b1cb5f15fc832b9b9336d571171b17