### PR TITLE
test: update chart expectations and reference cases

### DIFF
--- a/tests/chart-orientation.test.js
+++ b/tests/chart-orientation.test.js
@@ -1,44 +1,15 @@
 const assert = require('node:assert');
 const test = require('node:test');
-const app = require('../server/index.cjs');
+const { computePositions } = require('../src/lib/astro.js');
 
-test('calculateChart assigns ascendant sign to first house for multiple charts', async (t) => {
-  const server = app.listen(0);
-  t.after(() => server.close());
-  await new Promise((resolve) => server.once('listening', resolve));
-  const { port } = server.address();
-
-  const originalFetch = global.fetch;
-  global.fetch = (url, opts) => {
-    if (typeof url === 'string') {
-      if (url.startsWith('/api/')) {
-        return originalFetch(`http://localhost:${port}${url}`, opts);
-      }
-      if (url.startsWith('https://www.timeapi.io')) {
-        return Promise.reject(new Error('no external fetch'));
-      }
-    }
-    return originalFetch(url, opts);
-  };
-  t.after(() => {
-    global.fetch = originalFetch;
+test('planet house values match sign mapping and nodes oppose each other', async () => {
+  const data = await computePositions('2020-01-01T12:00+00:00', 0, 0);
+  data.planets.forEach((p) => {
+    assert.strictEqual(data.signInHouse[p.house], p.sign);
   });
-
-  const calculateChart = (await import('../src/calculateChart.js')).default;
-
-  const verify = async (params) => {
-    const chart = await calculateChart(params);
-    const asc = chart.ascSign;
-    assert.strictEqual(chart.signInHouse[1], asc);
-    const sun = chart.planets.find((p) => p.name === 'sun');
-    assert.strictEqual(chart.signInHouse[sun.house], sun.sign);
-  };
-
-  await t.test('Libra ascendant', () =>
-    verify({ date: '2020-10-17', time: '19:00', lat: 0, lon: 0 })
-  );
-
-  await t.test('Gemini ascendant', () =>
-    verify({ date: '2020-04-01', time: '00:00', lat: 0, lon: 0 })
-  );
+  const rahu = data.planets.find((p) => p.name === 'rahu');
+  const ketu = data.planets.find((p) => p.name === 'ketu');
+  assert.ok(rahu && ketu);
+  assert.strictEqual((ketu.sign - rahu.sign + 12) % 12, 6);
+  assert.strictEqual((ketu.house - rahu.house + 12) % 12, 6);
 });

--- a/tests/chart-render.test.js
+++ b/tests/chart-render.test.js
@@ -1,120 +1,45 @@
-const fs = require('node:fs');
-const path = require('node:path');
-const vm = require('node:vm');
 const assert = require('node:assert');
 const test = require('node:test');
+const { renderNorthIndian, diamondPath } = require('../src/lib/astro.js');
 
-function loadChart() {
-  let code = fs.readFileSync(path.join(__dirname, '../src/components/Chart.jsx'), 'utf8');
-  code = code.replace("import React from 'react';", "const React = { isValidElement: () => true };");
-  code = code.replace(
-    "import PropTypes from 'prop-types';",
-    'const PropTypes = new Proxy({}, { get: () => { const fn = () => fn; fn.isRequired = fn; return fn; }});'
-  );
-  code = code.replace('export default function Chart', 'function Chart');
-  code = code.replace(/export const /g, 'const ');
-  code = code.replace(
-    /return \([\s\S]*?\n\s*\);\n  }\n  const signInHouse/,
-    'return "Invalid chart data";\n  }\n  const signInHouse'
-  );
-  code = code.replace(
-    /if \(invalidHouses \|\| invalidPlanets\) {\n[\s\S]*?\n\s*}\n\n/,
-    'if (invalidHouses || invalidPlanets) {\n    return "Invalid chart data";\n  }\n\n'
-  );
-  code = code.replace(/if \(\n\s*children !== undefined[\s\S]*?\n\s*}\n\n/, '');
-  code = code.replace(
-    /\n  return \([\s\S]*?\n\s*\);\n}\n\nChart.propTypes/,
-    '\n  return "Chart";\n}\n\nChart.propTypes'
-  );
-  code += '\nmodule.exports = { default: Chart, HOUSE_POLYGONS };';
-  const sandbox = { module: {}, exports: {}, require };
-  vm.runInNewContext(code, sandbox);
-  return sandbox.module.exports;
+class Element {
+  constructor(tag) {
+    this.tagName = tag;
+    this.attributes = {};
+    this.children = [];
+    this.textContent = '';
+  }
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+  }
+  appendChild(child) {
+    this.children.push(child);
+  }
+  removeChild(child) {
+    const i = this.children.indexOf(child);
+    if (i >= 0) this.children.splice(i, 1);
+  }
+  get firstChild() {
+    return this.children[0];
+  }
 }
 
-test('Chart renders for valid house to sign maps regardless of ascendant', () => {
-  const { default: Chart } = loadChart();
+const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
-  const signInHouseForAsc = (asc) => {
-    const arr = Array(13).fill(null);
-    for (let i = 0; i < 12; i++) {
-      const house = i + 1;
-      arr[house] = (asc - 1 + i) % 12;
-    }
-    return arr;
-  };
+test('North Indian chart uses single outer diamond with internal grid', () => {
+  const svg = new Element('svg');
+  global.document = doc;
+  const signInHouse = [null];
+  for (let h = 1; h <= 12; h++) signInHouse[h] = h - 1;
+  renderNorthIndian(svg, { ascSign: 0, signInHouse, planets: [] });
 
-  const aries = signInHouseForAsc(1);
-  const libra = signInHouseForAsc(7);
-
-  assert.strictEqual(
-    Chart({ data: { signInHouse: aries, planets: [] } }),
-    'Chart'
-  );
-  assert.strictEqual(
-    Chart({ data: { signInHouse: libra, planets: [] } }),
-    'Chart'
-  );
-
-  assert.strictEqual(
-    Chart({ data: { signInHouse: aries.slice(1), planets: [] } }),
-    'Invalid chart data'
-  );
-  const tooLong = Array(14).fill(null);
-  for (let i = 1; i <= 13; i++) tooLong[i] = (i - 1) % 12;
-  assert.strictEqual(
-    Chart({ data: { signInHouse: tooLong, planets: [] } }),
-    'Invalid chart data'
-  );
-
-  const misordered = aries.slice();
-  [misordered[2], misordered[3]] = [misordered[3], misordered[2]];
-  assert.strictEqual(
-    Chart({ data: { signInHouse: misordered, planets: [] } }),
-    'Chart'
-  );
-});
-
-test('Chart SVG uses 12 distinct rhombi with no central cross', () => {
-  const { HOUSE_POLYGONS } = loadChart();
-  assert.strictEqual(HOUSE_POLYGONS.length, 12);
-  const paths = HOUSE_POLYGONS.map((p) => p.d);
-  const unique = new Set(paths);
-  assert.strictEqual(unique.size, 12);
-  const code = fs.readFileSync(
-    path.join(__dirname, '../src/components/Chart.jsx'),
-    'utf8'
-  );
-  assert.ok(!code.includes('<line'));
-});
-
-test('Planet labels are centred within house boxes', () => {
-  const code = fs.readFileSync(
-    path.join(__dirname, '../src/components/Chart.jsx'),
-    'utf8'
-  );
-  assert.ok(code.includes("top: `${p.cy}%`"));
-  assert.ok(code.includes("left: `${p.cx}%`"));
-  assert.ok(code.includes("transform: 'translate(-50%, -50%)'"));
-  assert.ok(code.includes('planetByHouse[houseNum] &&'));
-});
-
-test('Rhombi positions follow canonical North-Indian layout', () => {
-  const { HOUSE_POLYGONS } = loadChart();
-  const expected = [
-    [25, 50],
-    [25, 75],
-    [41.6667, 75],
-    [50, 75],
-    [75, 75],
-    [75, 58.3333],
-    [75, 50],
-    [75, 25],
-    [58.3333, 25],
-    [50, 25],
-    [25, 25],
-    [25, 41.6667],
-  ];
-  const coords = HOUSE_POLYGONS.map((p) => [p.cx, p.cy]);
-  assert.strictEqual(JSON.stringify(coords), JSON.stringify(expected));
+  const paths = svg.children.filter((c) => c.tagName === 'path');
+  assert.strictEqual(paths.length, 13);
+  assert.strictEqual(paths[0].attributes.d, diamondPath(50, 50, 50));
+  assert.strictEqual(paths[0].attributes['stroke-width'], '2');
+  for (let i = 1; i < paths.length; i++) {
+    assert.strictEqual(paths[i].attributes['stroke-width'], '1');
+  }
+  assert.ok(svg.children.every((el) => el.tagName !== 'line'));
+  delete global.document;
 });

--- a/tests/houses-order.test.js
+++ b/tests/houses-order.test.js
@@ -1,24 +1,16 @@
 const test = require('node:test');
 const assert = require('node:assert');
+const { computePositions } = require('../src/lib/astro.js');
 
-// Ensure calculateChart yields a natural zodiac sequence of signs
-// starting from the ascendant sign.
-test('calculateChart produces houses in natural zodiac order', async () => {
-  const calculateChart = (await import('../src/calculateChart.js')).default;
+// Ensure signInHouse rotates correctly from the ascendant and maintains cardinal orientation
 
-  const data = await calculateChart({
-    date: '2020-01-01',
-    time: '12:00',
-    lat: 0,
-    lon: 0,
-  });
-
-  const asc = data.ascSign;
-  const expected = Array(13).fill(null);
-  for (let i = 0; i < 12; i++) {
-    const house = i + 1;
-    const sign = (asc + i) % 12;
-    expected[house] = sign;
+test('computePositions produces houses in natural zodiac order', async () => {
+  const data = await computePositions('2020-01-01T12:00+00:00', 0, 0);
+  const k = data.ascSign;
+  for (let h = 1; h <= 12; h++) {
+    assert.strictEqual(data.signInHouse[h], (k + h - 1) % 12);
   }
-  assert.deepStrictEqual(data.signInHouse, expected);
+  assert.strictEqual(data.signInHouse[4], (data.signInHouse[1] + 3) % 12);
+  assert.strictEqual(data.signInHouse[7], (data.signInHouse[1] + 6) % 12);
+  assert.strictEqual(data.signInHouse[10], (data.signInHouse[1] + 9) % 12);
 });

--- a/tests/reference-case.test.js
+++ b/tests/reference-case.test.js
@@ -1,21 +1,63 @@
 const assert = require('node:assert');
 const test = require('node:test');
+const { computePositions, renderNorthIndian, diamondPath } = require('../src/lib/astro.js');
 
-async function getCompute() {
-  return (await import('../src/lib/ephemeris.js')).compute_positions;
+class Element {
+  constructor(tag) {
+    this.tagName = tag;
+    this.attributes = {};
+    this.children = [];
+    this.textContent = '';
+  }
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+  }
+  appendChild(child) {
+    this.children.push(child);
+  }
+  removeChild(child) {
+    const i = this.children.indexOf(child);
+    if (i >= 0) this.children.splice(i, 1);
+  }
+  get firstChild() {
+    return this.children[0];
+  }
 }
 
-test('reference chart matches known placements', async () => {
-  const compute_positions = await getCompute();
-  const res = compute_positions({
-    datetime: '1982-12-01T03:50',
-    tz: 'Asia/Kolkata',
-    lat: 26.152,
-    lon: 85.897,
-  });
-  assert.strictEqual(res.ascSign, 1);
-  const planets = Object.fromEntries(res.planets.map((p) => [p.name, p.sign]));
-  assert.strictEqual(planets.sun, 8);
-  assert.strictEqual(planets.moon, 2);
-  assert.strictEqual(planets.saturn, 6);
+const doc = { createElementNS: (ns, tag) => new Element(tag) };
+
+test('reference charts for Darbhanga on 1982-12-01 match expected placements', async () => {
+  const am = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
+  assert.strictEqual(am.ascSign, 0);
+  const amPlanets = Object.fromEntries(am.planets.map((p) => [p.name, p]));
+  assert.strictEqual(amPlanets.sun.sign, 7);
+  assert.strictEqual(amPlanets.sun.house, 8);
+  assert.strictEqual(amPlanets.moon.sign, 1);
+  assert.strictEqual(amPlanets.moon.house, 2);
+  assert.strictEqual(amPlanets.saturn.sign, 5);
+  assert.strictEqual(amPlanets.saturn.house, 6);
+
+  global.document = doc;
+  const svgAm = new Element('svg');
+  renderNorthIndian(svgAm, am);
+  assert.strictEqual(
+    svgAm.children.filter((c) => c.tagName === 'path').length,
+    13
+  );
+
+  const pm = await computePositions('1982-12-01T15:50+05:30', 26.152, 85.897);
+  assert.strictEqual(pm.ascSign, 6);
+  const pmPlanets = Object.fromEntries(pm.planets.map((p) => [p.name, p]));
+  assert.strictEqual(pmPlanets.sun.sign, 7);
+  assert.strictEqual(pmPlanets.sun.house, 2);
+  assert.strictEqual(pmPlanets.moon.sign, 1);
+  assert.strictEqual(pmPlanets.moon.house, 8);
+
+  const svgPm = new Element('svg');
+  renderNorthIndian(svgPm, pm);
+  assert.strictEqual(
+    svgPm.children.filter((c) => c.tagName === 'path').length,
+    13
+  );
+  delete global.document;
 });


### PR DESCRIPTION
## Summary
- Adapt chart rendering tests for single-diamond grid layout
- Check signInHouse rotation and cardinal house orientation
- Validate planetary house mapping, Rahu/Ketu opposition, and Darbhanga reference charts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2650883e4832b94219b76f1e5c453