### PR TITLE
Add shared house polygon constants

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -1,23 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { HOUSE_POLYGONS } from '../lib/astro.js';
 
-// Each entry defines the path and centre of a house polygon in the
-// fixed AstroSage-style layout. Houses are numbered counter-clockwise
-// starting from the left.
-export const HOUSE_POLYGONS = [
-  { d: 'M0 50 L25 25 L50 50 L25 75 Z', cx: 25, cy: 50 }, // 1
-  { d: 'M0 50 L25 75 L50 100 Z', cx: 25, cy: 75 }, // 2
-  { d: 'M25 75 L50 50 L50 100 Z', cx: 41.6667, cy: 75 }, // 3
-  { d: 'M50 100 L75 75 L50 50 L25 75 Z', cx: 50, cy: 75 }, // 4
-  { d: 'M50 100 L100 50 L75 75 Z', cx: 75, cy: 75 }, // 5
-  { d: 'M75 75 L50 50 L100 50 Z', cx: 75, cy: 58.3333 }, // 6
-  { d: 'M100 50 L75 25 L50 50 L75 75 Z', cx: 75, cy: 50 }, // 7
-  { d: 'M100 50 L50 0 L75 25 Z', cx: 75, cy: 25 }, // 8
-  { d: 'M75 25 L50 50 L50 0 Z', cx: 58.3333, cy: 25 }, // 9
-  { d: 'M50 0 L25 25 L50 50 L75 25 Z', cx: 50, cy: 25 }, // 10
-  { d: 'M50 0 L0 50 L25 25 Z', cx: 25, cy: 25 }, // 11
-  { d: 'M25 25 L50 50 L0 50 Z', cx: 25, cy: 41.6667 }, // 12
-];
+export { HOUSE_POLYGONS };
 
 const SIGN_LABELS = [
   'Ar',

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -35,6 +35,24 @@ export const SIGN_BOX_CENTERS = [
 
 const SIGN_LABELS = ['Ar', 'Ta', 'Ge', 'Cn', 'Le', 'Vi', 'Li', 'Sc', 'Sg', 'Cp', 'Aq', 'Pi'];
 
+// Each entry defines the path and centre of a house polygon in the
+// fixed AstroSage-style layout. Houses are numbered counter-clockwise
+// starting from the left.
+export const HOUSE_POLYGONS = [
+  { d: 'M0 50 L25 25 L50 50 L25 75 Z', cx: 25, cy: 50 }, // 1
+  { d: 'M0 50 L25 75 L50 100 Z', cx: 25, cy: 75 }, // 2
+  { d: 'M25 75 L50 50 L50 100 Z', cx: 41.6667, cy: 75 }, // 3
+  { d: 'M50 100 L75 75 L50 50 L25 75 Z', cx: 50, cy: 75 }, // 4
+  { d: 'M50 100 L100 50 L75 75 Z', cx: 75, cy: 75 }, // 5
+  { d: 'M75 75 L50 50 L100 50 Z', cx: 75, cy: 58.3333 }, // 6
+  { d: 'M100 50 L75 25 L50 50 L75 75 Z', cx: 75, cy: 50 }, // 7
+  { d: 'M100 50 L50 0 L75 25 Z', cx: 75, cy: 25 }, // 8
+  { d: 'M75 25 L50 50 L50 0 Z', cx: 58.3333, cy: 25 }, // 9
+  { d: 'M50 0 L25 25 L50 50 L75 25 Z', cx: 50, cy: 25 }, // 10
+  { d: 'M50 0 L0 50 L25 25 Z', cx: 25, cy: 25 }, // 11
+  { d: 'M25 25 L50 50 L0 50 Z', cx: 25, cy: 41.6667 }, // 12
+];
+
 export function diamondPath(cx, cy, size = BOX_SIZE) {
   return `M ${cx} ${cy - size} L ${cx + size} ${cy} L ${cx} ${cy + size} L ${cx - size} ${cy} Z`;
 }

--- a/tests/house-polygons.test.js
+++ b/tests/house-polygons.test.js
@@ -1,0 +1,25 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { HOUSE_POLYGONS } = require('../src/lib/astro.js');
+
+test('HOUSE_POLYGONS lists fixed paths for the twelve houses', () => {
+  assert.strictEqual(HOUSE_POLYGONS.length, 12);
+  const expected = [
+    'M0 50 L25 25 L50 50 L25 75 Z',
+    'M0 50 L25 75 L50 100 Z',
+    'M25 75 L50 50 L50 100 Z',
+    'M50 100 L75 75 L50 50 L25 75 Z',
+    'M50 100 L100 50 L75 75 Z',
+    'M75 75 L50 50 L100 50 Z',
+    'M100 50 L75 25 L50 50 L75 75 Z',
+    'M100 50 L50 0 L75 25 Z',
+    'M75 25 L50 50 L50 0 Z',
+    'M50 0 L25 25 L50 50 L75 25 Z',
+    'M50 0 L0 50 L25 25 Z',
+    'M25 25 L50 50 L0 50 Z',
+  ];
+  assert.deepStrictEqual(
+    HOUSE_POLYGONS.map((p) => p.d),
+    expected
+  );
+});


### PR DESCRIPTION
## Summary
- define and export HOUSE_POLYGONS in lib for reuse
- use shared house polygons in Chart component
- test house polygon paths for layout consistency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2669f7c78832b89e080ebb404b8ab