### PR TITLE
Orient house polygons from top

### DIFF
--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -37,20 +37,20 @@ const SIGN_LABELS = ['Ar', 'Ta', 'Ge', 'Cn', 'Le', 'Vi', 'Li', 'Sc', 'Sg', 'Cp',
 
 // Each entry defines the path and centre of a house polygon in the
 // fixed AstroSage-style layout. Houses are numbered counter-clockwise
-// starting from the left.
+// starting from the top diamond.
 export const HOUSE_POLYGONS = [
-  { d: 'M0 50 L25 25 L50 50 L25 75 Z', cx: 25, cy: 50 }, // 1
-  { d: 'M0 50 L25 75 L50 100 Z', cx: 25, cy: 75 }, // 2
-  { d: 'M25 75 L50 50 L50 100 Z', cx: 41.6667, cy: 75 }, // 3
-  { d: 'M50 100 L75 75 L50 50 L25 75 Z', cx: 50, cy: 75 }, // 4
-  { d: 'M50 100 L100 50 L75 75 Z', cx: 75, cy: 75 }, // 5
-  { d: 'M75 75 L50 50 L100 50 Z', cx: 75, cy: 58.3333 }, // 6
-  { d: 'M100 50 L75 25 L50 50 L75 75 Z', cx: 75, cy: 50 }, // 7
-  { d: 'M100 50 L50 0 L75 25 Z', cx: 75, cy: 25 }, // 8
-  { d: 'M75 25 L50 50 L50 0 Z', cx: 58.3333, cy: 25 }, // 9
-  { d: 'M50 0 L25 25 L50 50 L75 25 Z', cx: 50, cy: 25 }, // 10
-  { d: 'M50 0 L0 50 L25 25 Z', cx: 25, cy: 25 }, // 11
-  { d: 'M25 25 L50 50 L0 50 Z', cx: 25, cy: 41.6667 }, // 12
+  { d: 'M50 0 L25 25 L50 50 L75 25 Z', cx: 50, cy: 25 }, // 1
+  { d: 'M50 0 L0 50 L25 25 Z', cx: 25, cy: 25 }, // 2
+  { d: 'M25 25 L50 50 L0 50 Z', cx: 25, cy: 41.6667 }, // 3
+  { d: 'M0 50 L25 25 L50 50 L25 75 Z', cx: 25, cy: 50 }, // 4
+  { d: 'M0 50 L25 75 L50 100 Z', cx: 25, cy: 75 }, // 5
+  { d: 'M25 75 L50 50 L50 100 Z', cx: 41.6667, cy: 75 }, // 6
+  { d: 'M50 100 L75 75 L50 50 L25 75 Z', cx: 50, cy: 75 }, // 7
+  { d: 'M50 100 L100 50 L75 75 Z', cx: 75, cy: 75 }, // 8
+  { d: 'M75 75 L50 50 L100 50 Z', cx: 75, cy: 58.3333 }, // 9
+  { d: 'M100 50 L75 25 L50 50 L75 75 Z', cx: 75, cy: 50 }, // 10
+  { d: 'M100 50 L50 0 L75 25 Z', cx: 75, cy: 25 }, // 11
+  { d: 'M75 25 L50 50 L50 0 Z', cx: 58.3333, cy: 25 }, // 12
 ];
 
 export function diamondPath(cx, cy, size = BOX_SIZE) {

--- a/tests/house-polygons.test.js
+++ b/tests/house-polygons.test.js
@@ -5,6 +5,9 @@ const { HOUSE_POLYGONS } = require('../src/lib/astro.js');
 test('HOUSE_POLYGONS lists fixed paths for the twelve houses', () => {
   assert.strictEqual(HOUSE_POLYGONS.length, 12);
   const expected = [
+    'M50 0 L25 25 L50 50 L75 25 Z',
+    'M50 0 L0 50 L25 25 Z',
+    'M25 25 L50 50 L0 50 Z',
     'M0 50 L25 25 L50 50 L25 75 Z',
     'M0 50 L25 75 L50 100 Z',
     'M25 75 L50 50 L50 100 Z',
@@ -14,9 +17,6 @@ test('HOUSE_POLYGONS lists fixed paths for the twelve houses', () => {
     'M100 50 L75 25 L50 50 L75 75 Z',
     'M100 50 L50 0 L75 25 Z',
     'M75 25 L50 50 L50 0 Z',
-    'M50 0 L25 25 L50 50 L75 25 Z',
-    'M50 0 L0 50 L25 25 Z',
-    'M25 25 L50 50 L0 50 Z',
   ];
   assert.deepStrictEqual(
     HOUSE_POLYGONS.map((p) => p.d),


### PR DESCRIPTION
## Summary
- Rotate HOUSE_POLYGONS so house numbering begins at the top diamond and proceeds counter-clockwise
- Update comments and tests to reflect new orientation

## Testing
- `npm test`
- `node -e "const { computePositions } = require('./src/lib/astro.js'); (async () => { const data = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897); console.log('Asc sign:', data.ascSign); console.log('signInHouse[1-4]:', data.signInHouse.slice(1,5)); })();"`


------
https://chatgpt.com/codex/tasks/task_e_68b273bda9d0832b8e045f20f66e4fb2