### PR TITLE
feat: support numeric rashi labels

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -1,25 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { HOUSE_POLYGONS } from '../lib/astro.js';
+import { HOUSE_POLYGONS, getSignLabel } from '../lib/astro.js';
 
 export { HOUSE_POLYGONS };
 
-const SIGN_LABELS = [
-  'Ar',
-  'Ta',
-  'Ge',
-  'Cn',
-  'Le',
-  'Vi',
-  'Li',
-  'Sc',
-  'Sg',
-  'Cp',
-  'Aq',
-  'Pi',
-];
-
-export default function Chart({ data, children }) {
+export default function Chart({ data, children, useAbbreviations = false }) {
   if (
     !data ||
     !Array.isArray(data.signInHouse) ||
@@ -87,7 +72,7 @@ export default function Chart({ data, children }) {
               )}
               {signIdx !== undefined && (
                 <span className="text-orange-300 font-semibold text-[clamp(0.5rem,0.8vw,0.75rem)]">
-                  {SIGN_LABELS[signIdx]}
+                  {getSignLabel(signIdx, { useAbbreviations })}
                 </span>
               )}
               {planetByHouse[houseNum] &&
@@ -122,5 +107,6 @@ Chart.propTypes = {
     ).isRequired,
   }).isRequired,
   children: PropTypes.node,
+  useAbbreviations: PropTypes.bool,
 };
 

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -33,7 +33,27 @@ export const SIGN_BOX_CENTERS = [
   { cx: 25, cy: 12.5 }, // Pisces
 ];
 
-const SIGN_LABELS = ['Ar', 'Ta', 'Ge', 'Cn', 'Le', 'Vi', 'Li', 'Sc', 'Sg', 'Cp', 'Aq', 'Pi'];
+// Sign label helpers. By default signs are labelled 1-12.
+export const SIGN_NUMBERS = Array.from({ length: 12 }, (_, i) => String(i + 1));
+export const SIGN_ABBREVIATIONS = [
+  'Ar',
+  'Ta',
+  'Ge',
+  'Cn',
+  'Le',
+  'Vi',
+  'Li',
+  'Sc',
+  'Sg',
+  'Cp',
+  'Aq',
+  'Pi',
+];
+
+export function getSignLabel(index, { useAbbreviations = false } = {}) {
+  const labels = useAbbreviations ? SIGN_ABBREVIATIONS : SIGN_NUMBERS;
+  return labels[index] ?? String(index + 1);
+}
 
 // Each entry defines the path and centre of a house polygon in the
 // fixed AstroSage-style layout. Houses are numbered counter-clockwise
@@ -140,7 +160,7 @@ export async function computePositions(dtISOWithZone, lat, lon) {
   return { ascSign: asc.sign, signInHouse, planets };
 }
 
-export function renderNorthIndian(svgEl, data) {
+export function renderNorthIndian(svgEl, data, options = {}) {
   while (svgEl.firstChild) svgEl.removeChild(svgEl.firstChild);
   svgEl.setAttribute('viewBox', '0 0 100 100');
   svgEl.setAttribute('fill', 'none');
@@ -172,7 +192,7 @@ export function renderNorthIndian(svgEl, data) {
     signText.setAttribute('y', cy - BOX_SIZE + 4);
     signText.setAttribute('text-anchor', 'middle');
     signText.setAttribute('font-size', '4');
-    signText.textContent = SIGN_LABELS[i];
+    signText.textContent = getSignLabel(i, options);
     svgEl.appendChild(signText);
 
     const houseNum = signToHouse[i];

--- a/tests/sign-labels.test.js
+++ b/tests/sign-labels.test.js
@@ -1,0 +1,58 @@
+const assert = require('node:assert');
+const test = require('node:test');
+const { renderNorthIndian } = require('../src/lib/astro.js');
+
+class Element {
+  constructor(tag) {
+    this.tagName = tag;
+    this.attributes = {};
+    this.children = [];
+    this.textContent = '';
+  }
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+  }
+  appendChild(child) {
+    this.children.push(child);
+  }
+  removeChild(child) {
+    const i = this.children.indexOf(child);
+    if (i >= 0) this.children.splice(i, 1);
+  }
+  get firstChild() {
+    return this.children[0];
+  }
+}
+
+const doc = { createElementNS: (ns, tag) => new Element(tag) };
+
+test('renderNorthIndian defaults to numeric sign labels', () => {
+  const signInHouse = [null];
+  for (let h = 1; h <= 12; h++) signInHouse[h] = h - 1;
+  global.document = doc;
+  const svg = new Element('svg');
+  renderNorthIndian(svg, { ascSign: 0, signInHouse, planets: [] });
+  const texts = svg.children.filter(
+    (c) => c.tagName === 'text' && c.attributes['font-size'] === '4'
+  );
+  const labels = texts.map((t) => t.textContent);
+  assert.deepStrictEqual(labels, ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']);
+  delete global.document;
+});
+
+test('renderNorthIndian can use abbreviated sign labels', () => {
+  const signInHouse = [null];
+  for (let h = 1; h <= 12; h++) signInHouse[h] = h - 1;
+  global.document = doc;
+  const svg = new Element('svg');
+  renderNorthIndian(svg, { ascSign: 0, signInHouse, planets: [] }, {
+    useAbbreviations: true,
+  });
+  const texts = svg.children.filter(
+    (c) => c.tagName === 'text' && c.attributes['font-size'] === '4'
+  );
+  const labels = texts.map((t) => t.textContent);
+  assert.deepStrictEqual(labels, ['Ar', 'Ta', 'Ge', 'Cn', 'Le', 'Vi', 'Li', 'Sc', 'Sg', 'Cp', 'Aq', 'Pi']);
+  delete global.document;
+});
+


### PR DESCRIPTION
## Summary
- display signs as numeric strings by default and expose abbreviation option
- allow Chart component and renderNorthIndian to toggle numeric vs abbreviated sign labels
- add tests for sign label configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b274ede584832bb721ea38d10d8d09