### PR TITLE
List house polygons clockwise

### DIFF
--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -56,21 +56,21 @@ export function getSignLabel(index, { useAbbreviations = false } = {}) {
 }
 
 // Each entry defines the path and centre of a house polygon in the
-// fixed AstroSage-style layout. Houses are numbered counter-clockwise
+// fixed AstroSage-style layout. Houses are numbered clockwise
 // starting from the top diamond.
 export const HOUSE_POLYGONS = [
   { d: 'M50 0 L25 25 L50 50 L75 25 Z', cx: 50, cy: 25 }, // 1
-  { d: 'M50 0 L0 50 L25 25 Z', cx: 25, cy: 25 }, // 2
-  { d: 'M25 25 L50 50 L0 50 Z', cx: 25, cy: 41.6667 }, // 3
-  { d: 'M0 50 L25 25 L50 50 L25 75 Z', cx: 25, cy: 50 }, // 4
-  { d: 'M0 50 L25 75 L50 100 Z', cx: 25, cy: 75 }, // 5
-  { d: 'M25 75 L50 50 L50 100 Z', cx: 41.6667, cy: 75 }, // 6
+  { d: 'M75 25 L50 50 L50 0 Z', cx: 58.3333, cy: 25 }, // 2
+  { d: 'M100 50 L50 0 L75 25 Z', cx: 75, cy: 25 }, // 3
+  { d: 'M100 50 L75 25 L50 50 L75 75 Z', cx: 75, cy: 50 }, // 4
+  { d: 'M75 75 L50 50 L100 50 Z', cx: 75, cy: 58.3333 }, // 5
+  { d: 'M50 100 L100 50 L75 75 Z', cx: 75, cy: 75 }, // 6
   { d: 'M50 100 L75 75 L50 50 L25 75 Z', cx: 50, cy: 75 }, // 7
-  { d: 'M50 100 L100 50 L75 75 Z', cx: 75, cy: 75 }, // 8
-  { d: 'M75 75 L50 50 L100 50 Z', cx: 75, cy: 58.3333 }, // 9
-  { d: 'M100 50 L75 25 L50 50 L75 75 Z', cx: 75, cy: 50 }, // 10
-  { d: 'M100 50 L50 0 L75 25 Z', cx: 75, cy: 25 }, // 11
-  { d: 'M75 25 L50 50 L50 0 Z', cx: 58.3333, cy: 25 }, // 12
+  { d: 'M25 75 L50 50 L50 100 Z', cx: 41.6667, cy: 75 }, // 8
+  { d: 'M0 50 L25 75 L50 100 Z', cx: 25, cy: 75 }, // 9
+  { d: 'M0 50 L25 25 L50 50 L25 75 Z', cx: 25, cy: 50 }, // 10
+  { d: 'M25 25 L50 50 L0 50 Z', cx: 25, cy: 41.6667 }, // 11
+  { d: 'M50 0 L0 50 L25 25 Z', cx: 25, cy: 25 }, // 12
 ];
 
 export function diamondPath(cx, cy, size = BOX_SIZE) {

--- a/tests/house-polygons.test.js
+++ b/tests/house-polygons.test.js
@@ -6,17 +6,17 @@ test('HOUSE_POLYGONS lists fixed paths for the twelve houses', () => {
   assert.strictEqual(HOUSE_POLYGONS.length, 12);
   const expected = [
     'M50 0 L25 25 L50 50 L75 25 Z',
-    'M50 0 L0 50 L25 25 Z',
-    'M25 25 L50 50 L0 50 Z',
-    'M0 50 L25 25 L50 50 L25 75 Z',
-    'M0 50 L25 75 L50 100 Z',
-    'M25 75 L50 50 L50 100 Z',
-    'M50 100 L75 75 L50 50 L25 75 Z',
-    'M50 100 L100 50 L75 75 Z',
-    'M75 75 L50 50 L100 50 Z',
-    'M100 50 L75 25 L50 50 L75 75 Z',
-    'M100 50 L50 0 L75 25 Z',
     'M75 25 L50 50 L50 0 Z',
+    'M100 50 L50 0 L75 25 Z',
+    'M100 50 L75 25 L50 50 L75 75 Z',
+    'M75 75 L50 50 L100 50 Z',
+    'M50 100 L100 50 L75 75 Z',
+    'M50 100 L75 75 L50 50 L25 75 Z',
+    'M25 75 L50 50 L50 100 Z',
+    'M0 50 L25 75 L50 100 Z',
+    'M0 50 L25 25 L50 50 L25 75 Z',
+    'M25 25 L50 50 L0 50 Z',
+    'M50 0 L0 50 L25 25 Z',
   ];
   assert.deepStrictEqual(
     HOUSE_POLYGONS.map((p) => p.d),


### PR DESCRIPTION
## Summary
- reorder `HOUSE_POLYGONS` to follow clockwise numbering from top
- adjust house polygon test expectations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2787f8a6c832bbe00a6e0736f6bd7