### PR TITLE
test: verify chart orientation

### DIFF
--- a/tests/chart-orientation-ascendant.test.js
+++ b/tests/chart-orientation-ascendant.test.js
@@ -1,0 +1,55 @@
+const assert = require('node:assert');
+const test = require('node:test');
+const { renderNorthIndian, SIGN_BOX_CENTERS, BOX_SIZE } = require('../src/lib/astro.js');
+
+class Element {
+  constructor(tag) {
+    this.tagName = tag;
+    this.attributes = {};
+    this.children = [];
+    this.textContent = '';
+  }
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+  }
+  appendChild(child) {
+    this.children.push(child);
+  }
+  removeChild(child) {
+    const i = this.children.indexOf(child);
+    if (i >= 0) this.children.splice(i, 1);
+  }
+  get firstChild() {
+    return this.children[0];
+  }
+}
+
+const doc = { createElementNS: (ns, tag) => new Element(tag) };
+
+test('renderNorthIndian and Chart orient Aries ascendant clockwise', () => {
+  const signInHouse = [null];
+  for (let h = 1; h <= 12; h++) signInHouse[h] = h - 1;
+  const data = { ascSign: 0, signInHouse, planets: [] };
+
+  global.document = doc;
+  const svg = new Element('svg');
+  renderNorthIndian(svg, data);
+  const houseTexts = svg.children.filter(
+    (c) =>
+      c.tagName === 'text' &&
+      c.attributes['font-size'] === '3' &&
+      /^\d+$/.test(c.textContent)
+  );
+  assert.strictEqual(houseTexts.length, 12);
+  for (let i = 0; i < 12; i++) {
+    const t = houseTexts.find((ht) => ht.textContent === String(i + 1));
+    assert.ok(t, `house ${i + 1} missing`);
+    const expected = SIGN_BOX_CENTERS[i];
+    assert.strictEqual(Number(t.attributes.x), expected.cx - BOX_SIZE + 2);
+    assert.strictEqual(Number(t.attributes.y), expected.cy - BOX_SIZE + 4);
+  }
+  delete global.document;
+
+  const chartCenters = signInHouse.slice(1).map((s) => SIGN_BOX_CENTERS[s]);
+  assert.deepStrictEqual(chartCenters, SIGN_BOX_CENTERS);
+});


### PR DESCRIPTION
## Summary
- add orientation test for Aries ascendant to check clockwise house mapping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b27a3d816c832b9ff616bf241872fa