### PR TITLE
Render chart using house polygons

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -1,11 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  diamondPath,
-  BOX_SIZE,
-  SIGN_BOX_CENTERS,
-  getSignLabel,
-} from '../lib/astro.js';
+import { diamondPath, HOUSE_POLYGONS, getSignLabel } from '../lib/astro.js';
 
 export default function Chart({ data, children, useAbbreviations = false }) {
   if (
@@ -20,12 +15,6 @@ export default function Chart({ data, children, useAbbreviations = false }) {
     );
   }
   const signInHouse = data.signInHouse;
-
-  const signToHouse = {};
-  for (let h = 1; h <= 12; h++) {
-    const s = signInHouse[h];
-    if (s !== undefined) signToHouse[s] = h;
-  }
 
   const planetBySign = {};
   data.planets.forEach((p) => {
@@ -55,16 +44,16 @@ export default function Chart({ data, children, useAbbreviations = false }) {
           stroke="currentColor"
         >
           <path d={diamondPath(50, 50, 50)} strokeWidth="2" />
-          {SIGN_BOX_CENTERS.map(({ cx, cy }, idx) => (
-            <path key={idx} d={diamondPath(cx, cy, BOX_SIZE)} strokeWidth="1" />
+          {HOUSE_POLYGONS.map(({ d }, idx) => (
+            <path key={idx} d={d} strokeWidth="1" />
           ))}
         </svg>
-        {SIGN_BOX_CENTERS.map(({ cx, cy }, idx) => {
-          const signIdx = idx;
-          const houseNum = signToHouse[signIdx];
+        {HOUSE_POLYGONS.map(({ cx, cy }, idx) => {
+          const houseNum = idx + 1;
+          const signIdx = signInHouse[houseNum];
           return (
             <div
-              key={signIdx}
+              key={houseNum}
               className="absolute flex flex-col items-center text-xs gap-[2px] p-[2px]"
               style={{
                 top: `${cy}%`,
@@ -72,11 +61,9 @@ export default function Chart({ data, children, useAbbreviations = false }) {
                 transform: 'translate(-50%, -50%)',
               }}
             >
-              {houseNum !== undefined && (
-                <span className="text-yellow-300/40 text-[0.6rem] leading-none">
-                  {houseNum}
-                </span>
-              )}
+              <span className="text-yellow-300/40 text-[0.6rem] leading-none">
+                {houseNum}
+              </span>
               {houseNum === 1 && (
                 <span className="text-yellow-300 text-[0.6rem] leading-none">
                   La/Asc

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -171,61 +171,54 @@ export function renderNorthIndian(svgEl, data, options = {}) {
   outer.setAttribute('stroke-width', '2');
   svgEl.appendChild(outer);
 
-  const signToHouse = {};
-  if (Array.isArray(data.signInHouse)) {
-    for (let h = 1; h <= 12; h++) {
-      const s = data.signInHouse[h];
-      if (s !== undefined) signToHouse[s] = h;
-    }
-  }
+  for (let h = 1; h <= 12; h++) {
+    const poly = HOUSE_POLYGONS[h - 1];
+    const { d, cx, cy } = poly;
 
-  for (let i = 0; i < 12; i++) {
-    const { cx, cy } = SIGN_BOX_CENTERS[i];
+    const path = document.createElementNS(svgNS, 'path');
+    path.setAttribute('d', d);
+    path.setAttribute('stroke-width', '1');
+    svgEl.appendChild(path);
 
-    const box = document.createElementNS(svgNS, 'path');
-    box.setAttribute('d', diamondPath(cx, cy, BOX_SIZE));
-    box.setAttribute('stroke-width', '1');
-    svgEl.appendChild(box);
+    const signIdx = data.signInHouse?.[h] ?? h - 1;
 
-    const signText = document.createElementNS(svgNS, 'text');
-    signText.setAttribute('x', cx);
-    signText.setAttribute('y', cy - BOX_SIZE + 4);
-    signText.setAttribute('text-anchor', 'middle');
-    signText.setAttribute('font-size', '4');
-    signText.textContent = getSignLabel(i, options);
-    svgEl.appendChild(signText);
+    const hText = document.createElementNS(svgNS, 'text');
+    hText.setAttribute('x', cx);
+    hText.setAttribute('y', cy - 6);
+    hText.setAttribute('text-anchor', 'middle');
+    hText.setAttribute('font-size', '3');
+    hText.textContent = String(h);
+    svgEl.appendChild(hText);
 
-    const houseNum = signToHouse[i];
-    if (houseNum) {
-      const hText = document.createElementNS(svgNS, 'text');
-      hText.setAttribute('x', cx - BOX_SIZE + 2);
-      hText.setAttribute('y', cy - BOX_SIZE + 4);
-      hText.setAttribute('font-size', '3');
-      hText.textContent = String(houseNum);
-      svgEl.appendChild(hText);
-    }
-
-    if (i === data.ascSign) {
+    if (h === 1) {
       const ascText = document.createElementNS(svgNS, 'text');
       ascText.setAttribute('x', cx);
-      ascText.setAttribute('y', cy + BOX_SIZE - 2);
+      ascText.setAttribute('y', cy + 8);
       ascText.setAttribute('text-anchor', 'middle');
       ascText.setAttribute('font-size', '3');
       ascText.textContent = 'Asc';
       svgEl.appendChild(ascText);
     }
 
-    const planets = data.planets.filter((p) => p.sign === i);
-    let py = cy - BOX_SIZE / 2 + 8;
+    const signText = document.createElementNS(svgNS, 'text');
+    signText.setAttribute('x', cx);
+    signText.setAttribute('y', cy);
+    signText.setAttribute('text-anchor', 'middle');
+    signText.setAttribute('font-size', '4');
+    signText.textContent = getSignLabel(signIdx, options);
+    svgEl.appendChild(signText);
+
+    const planets = data.planets.filter((p) => p.sign === signIdx);
+    let py = cy + 4;
     planets.forEach((p) => {
       const t = document.createElementNS(svgNS, 'text');
       t.setAttribute('x', cx);
       t.setAttribute('y', py);
       t.setAttribute('text-anchor', 'middle');
       t.setAttribute('font-size', '3');
-      const d = Math.floor(p.deg);
-      const m = Math.round((p.deg - d) * 60);
-      const degStr = `${String(d).padStart(2, '0')}°${String(m).padStart(2, '0')}'`;
+      const dVal = Math.floor(p.deg);
+      const m = Math.round((p.deg - dVal) * 60);
+      const degStr = `${String(dVal).padStart(2, '0')}°${String(m).padStart(2, '0')}'`;
       t.textContent = `${p.name} ${degStr}${p.retro ? ' R' : ''}`;
       svgEl.appendChild(t);
       py += 4;

--- a/tests/chart-orientation-ascendant.test.js
+++ b/tests/chart-orientation-ascendant.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const test = require('node:test');
-const { renderNorthIndian, SIGN_BOX_CENTERS, BOX_SIZE } = require('../src/lib/astro.js');
+const { renderNorthIndian, HOUSE_POLYGONS } = require('../src/lib/astro.js');
 
 class Element {
   constructor(tag) {
@@ -44,12 +44,12 @@ test('renderNorthIndian and Chart orient Aries ascendant clockwise', () => {
   for (let i = 0; i < 12; i++) {
     const t = houseTexts.find((ht) => ht.textContent === String(i + 1));
     assert.ok(t, `house ${i + 1} missing`);
-    const expected = SIGN_BOX_CENTERS[i];
-    assert.strictEqual(Number(t.attributes.x), expected.cx - BOX_SIZE + 2);
-    assert.strictEqual(Number(t.attributes.y), expected.cy - BOX_SIZE + 4);
+    const expected = HOUSE_POLYGONS[i];
+    assert.strictEqual(Number(t.attributes.x), expected.cx);
+    assert.strictEqual(Number(t.attributes.y), expected.cy - 6);
   }
   delete global.document;
 
-  const chartCenters = signInHouse.slice(1).map((s) => SIGN_BOX_CENTERS[s]);
-  assert.deepStrictEqual(chartCenters, SIGN_BOX_CENTERS);
+  const chartPolys = signInHouse.slice(1).map((s) => HOUSE_POLYGONS[s]);
+  assert.deepStrictEqual(chartPolys, HOUSE_POLYGONS);
 });

--- a/tests/chart-render.test.js
+++ b/tests/chart-render.test.js
@@ -1,6 +1,10 @@
 const assert = require('node:assert');
 const test = require('node:test');
-const { renderNorthIndian, diamondPath } = require('../src/lib/astro.js');
+const {
+  renderNorthIndian,
+  diamondPath,
+  HOUSE_POLYGONS,
+} = require('../src/lib/astro.js');
 
 class Element {
   constructor(tag) {
@@ -37,8 +41,9 @@ test('North Indian chart uses single outer diamond with internal grid', () => {
   assert.strictEqual(paths.length, 13);
   assert.strictEqual(paths[0].attributes.d, diamondPath(50, 50, 50));
   assert.strictEqual(paths[0].attributes['stroke-width'], '2');
-  for (let i = 1; i < paths.length; i++) {
-    assert.strictEqual(paths[i].attributes['stroke-width'], '1');
+  for (let i = 0; i < 12; i++) {
+    assert.strictEqual(paths[i + 1].attributes['stroke-width'], '1');
+    assert.strictEqual(paths[i + 1].attributes.d, HOUSE_POLYGONS[i].d);
   }
   assert.ok(svg.children.every((el) => el.tagName !== 'line'));
   delete global.document;


### PR DESCRIPTION
## Summary
- replace sign boxes with HOUSE_POLYGONS when rendering the chart
- center sign and house labels within each polygon and keep outer diamond boundary
- add tests verifying 12 house polygons with expected shapes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b27f6169d0832b9ddaa97d5bb5226a