### PR TITLE
Refactor north Indian chart geometry

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { diamondPath, HOUSE_POLYGONS, getSignLabel } from '../lib/astro.js';
+import { CHART_PATHS, HOUSE_POLYGONS, getSignLabel } from '../lib/astro.js';
 
 export default function Chart({ data, children, useAbbreviations = false }) {
   if (
@@ -43,10 +43,11 @@ export default function Chart({ data, children, useAbbreviations = false }) {
           fill="none"
           stroke="currentColor"
         >
-          <path d={diamondPath(50, 50, 50)} strokeWidth="2" />
-          {HOUSE_POLYGONS.map(({ d }, idx) => (
-            <path key={idx} d={d} strokeWidth="1" />
+          <path d={CHART_PATHS.outer} strokeWidth="2" />
+          {CHART_PATHS.diagonals.map((d, idx) => (
+            <path key={`diag-${idx}`} d={d} strokeWidth="1" />
           ))}
+          <path d={CHART_PATHS.inner} strokeWidth="1" />
         </svg>
         {HOUSE_POLYGONS.map(({ cx, cy }, idx) => {
           const houseNum = idx + 1;


### PR DESCRIPTION
## Summary
- compute chart lines and house polygons programmatically
- expose reusable CHART_PATHS and HOUSE_POLYGONS
- render Chart using generated paths instead of hard-coded polygons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b283ae07e8832b93c7a8a25ef53db3