### PR TITLE
Normalize chart geometry to unit coordinates

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -38,16 +38,16 @@ export default function Chart({ data, children, useAbbreviations = false }) {
     <div className="backdrop-blur-md bg-white/5 border border-white/10 rounded-xl p-6 flex items-center justify-center">
       <div className="relative" style={{ width: size, height: size }}>
         <svg
-          viewBox="0 0 100 100"
+          viewBox="0 0 1 1"
           className="absolute inset-0 text-orange-500"
           fill="none"
           stroke="currentColor"
         >
-          <path d={CHART_PATHS.outer} strokeWidth="2" />
+          <path d={CHART_PATHS.outer} strokeWidth={0.02} />
           {CHART_PATHS.diagonals.map((d, idx) => (
-            <path key={`diag-${idx}`} d={d} strokeWidth="1" />
+            <path key={`diag-${idx}`} d={d} strokeWidth={0.01} />
           ))}
-          <path d={CHART_PATHS.inner} strokeWidth="1" />
+          <path d={CHART_PATHS.inner} strokeWidth={0.01} />
         </svg>
         {HOUSE_POLYGONS.map(({ cx, cy }, idx) => {
           const houseNum = idx + 1;
@@ -57,8 +57,8 @@ export default function Chart({ data, children, useAbbreviations = false }) {
               key={houseNum}
               className="absolute flex flex-col items-center text-xs gap-[2px] p-[2px]"
               style={{
-                top: `${cy}%`,
-                left: `${cx}%`,
+                top: cy * size,
+                left: cx * size,
                 transform: 'translate(-50%, -50%)',
               }}
             >

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -17,20 +17,20 @@ function lonToSignDeg(longitude) {
   return { sign, deg };
 }
 
-export const BOX_SIZE = 12.5;
+export const BOX_SIZE = 0.125;
 export const SIGN_BOX_CENTERS = [
-  { cx: 50, cy: 12.5 }, // Aries
-  { cx: 75, cy: 12.5 }, // Taurus
-  { cx: 87.5, cy: 25 }, // Gemini
-  { cx: 87.5, cy: 50 }, // Cancer
-  { cx: 87.5, cy: 75 }, // Leo
-  { cx: 75, cy: 87.5 }, // Virgo
-  { cx: 50, cy: 87.5 }, // Libra
-  { cx: 25, cy: 87.5 }, // Scorpio
-  { cx: 12.5, cy: 75 }, // Sagittarius
-  { cx: 12.5, cy: 50 }, // Capricorn
-  { cx: 12.5, cy: 25 }, // Aquarius
-  { cx: 25, cy: 12.5 }, // Pisces
+  { cx: 0.5, cy: 0.125 }, // Aries
+  { cx: 0.75, cy: 0.125 }, // Taurus
+  { cx: 0.875, cy: 0.25 }, // Gemini
+  { cx: 0.875, cy: 0.5 }, // Cancer
+  { cx: 0.875, cy: 0.75 }, // Leo
+  { cx: 0.75, cy: 0.875 }, // Virgo
+  { cx: 0.5, cy: 0.875 }, // Libra
+  { cx: 0.25, cy: 0.875 }, // Scorpio
+  { cx: 0.125, cy: 0.75 }, // Sagittarius
+  { cx: 0.125, cy: 0.5 }, // Capricorn
+  { cx: 0.125, cy: 0.25 }, // Aquarius
+  { cx: 0.25, cy: 0.125 }, // Pisces
 ];
 
 // Sign label helpers. By default signs are labelled 1-12.
@@ -56,7 +56,7 @@ export function getSignLabel(index, { useAbbreviations = false } = {}) {
 }
 
 // Derive chart geometry and house polygons programmatically.
-function buildHouseGeometry(scale = 100) {
+function buildHouseGeometry(scale = 1) {
   const O = [0.5, 0.5];
   const mid = [
     [0.5, 0],
@@ -203,13 +203,13 @@ export async function computePositions(dtISOWithZone, lat, lon) {
 
 export function renderNorthIndian(svgEl, data, options = {}) {
   while (svgEl.firstChild) svgEl.removeChild(svgEl.firstChild);
-  svgEl.setAttribute('viewBox', '0 0 100 100');
+  svgEl.setAttribute('viewBox', '0 0 1 1');
   svgEl.setAttribute('fill', 'none');
   svgEl.setAttribute('stroke', 'currentColor');
 
   const outer = document.createElementNS(svgNS, 'path');
-  outer.setAttribute('d', diamondPath(50, 50, 50));
-  outer.setAttribute('stroke-width', '2');
+  outer.setAttribute('d', diamondPath(0.5, 0.5, 0.5));
+  outer.setAttribute('stroke-width', '0.02');
   svgEl.appendChild(outer);
 
   for (let h = 1; h <= 12; h++) {
@@ -218,25 +218,25 @@ export function renderNorthIndian(svgEl, data, options = {}) {
 
     const path = document.createElementNS(svgNS, 'path');
     path.setAttribute('d', d);
-    path.setAttribute('stroke-width', '1');
+    path.setAttribute('stroke-width', '0.01');
     svgEl.appendChild(path);
 
     const signIdx = data.signInHouse?.[h] ?? h - 1;
 
     const hText = document.createElementNS(svgNS, 'text');
     hText.setAttribute('x', cx);
-    hText.setAttribute('y', cy - 6);
+    hText.setAttribute('y', cy - 0.06);
     hText.setAttribute('text-anchor', 'middle');
-    hText.setAttribute('font-size', '3');
+    hText.setAttribute('font-size', '0.03');
     hText.textContent = String(h);
     svgEl.appendChild(hText);
 
     if (h === 1) {
       const ascText = document.createElementNS(svgNS, 'text');
       ascText.setAttribute('x', cx);
-      ascText.setAttribute('y', cy + 8);
+      ascText.setAttribute('y', cy + 0.08);
       ascText.setAttribute('text-anchor', 'middle');
-      ascText.setAttribute('font-size', '3');
+      ascText.setAttribute('font-size', '0.03');
       ascText.textContent = 'Asc';
       svgEl.appendChild(ascText);
     }
@@ -245,24 +245,24 @@ export function renderNorthIndian(svgEl, data, options = {}) {
     signText.setAttribute('x', cx);
     signText.setAttribute('y', cy);
     signText.setAttribute('text-anchor', 'middle');
-    signText.setAttribute('font-size', '4');
+    signText.setAttribute('font-size', '0.04');
     signText.textContent = getSignLabel(signIdx, options);
     svgEl.appendChild(signText);
 
     const planets = data.planets.filter((p) => p.sign === signIdx);
-    let py = cy + 4;
+    let py = cy + 0.04;
     planets.forEach((p) => {
       const t = document.createElementNS(svgNS, 'text');
       t.setAttribute('x', cx);
       t.setAttribute('y', py);
       t.setAttribute('text-anchor', 'middle');
-      t.setAttribute('font-size', '3');
+      t.setAttribute('font-size', '0.03');
       const dVal = Math.floor(p.deg);
       const m = Math.round((p.deg - dVal) * 60);
       const degStr = `${String(dVal).padStart(2, '0')}°${String(m).padStart(2, '0')}'`;
       t.textContent = `${p.name} ${degStr}${p.retro ? ' R' : ''}`;
       svgEl.appendChild(t);
-      py += 4;
+      py += 0.04;
     });
   }
 }

--- a/tests/chart-orientation-ascendant.test.js
+++ b/tests/chart-orientation-ascendant.test.js
@@ -37,7 +37,7 @@ test('renderNorthIndian and Chart orient Aries ascendant clockwise', () => {
   const houseTexts = svg.children.filter(
     (c) =>
       c.tagName === 'text' &&
-      c.attributes['font-size'] === '3' &&
+      c.attributes['font-size'] === '0.03' &&
       /^\d+$/.test(c.textContent)
   );
   assert.strictEqual(houseTexts.length, 12);
@@ -46,7 +46,7 @@ test('renderNorthIndian and Chart orient Aries ascendant clockwise', () => {
     assert.ok(t, `house ${i + 1} missing`);
     const expected = HOUSE_POLYGONS[i];
     assert.strictEqual(Number(t.attributes.x), expected.cx);
-    assert.strictEqual(Number(t.attributes.y), expected.cy - 6);
+    assert.strictEqual(Number(t.attributes.y), expected.cy - 0.06);
   }
   delete global.document;
 

--- a/tests/chart-render.test.js
+++ b/tests/chart-render.test.js
@@ -39,10 +39,10 @@ test('North Indian chart uses single outer diamond with internal grid', () => {
 
   const paths = svg.children.filter((c) => c.tagName === 'path');
   assert.strictEqual(paths.length, 13);
-  assert.strictEqual(paths[0].attributes.d, diamondPath(50, 50, 50));
-  assert.strictEqual(paths[0].attributes['stroke-width'], '2');
+  assert.strictEqual(paths[0].attributes.d, diamondPath(0.5, 0.5, 0.5));
+  assert.strictEqual(paths[0].attributes['stroke-width'], '0.02');
   for (let i = 0; i < 12; i++) {
-    assert.strictEqual(paths[i + 1].attributes['stroke-width'], '1');
+    assert.strictEqual(paths[i + 1].attributes['stroke-width'], '0.01');
     assert.strictEqual(paths[i + 1].attributes.d, HOUSE_POLYGONS[i].d);
   }
   assert.ok(svg.children.every((el) => el.tagName !== 'line'));

--- a/tests/house-polygons.test.js
+++ b/tests/house-polygons.test.js
@@ -5,18 +5,18 @@ const { HOUSE_POLYGONS } = require('../src/lib/astro.js');
 test('HOUSE_POLYGONS lists fixed paths for the twelve houses', () => {
   assert.strictEqual(HOUSE_POLYGONS.length, 12);
   const expected = [
-    'M50 0 L25 25 L50 50 L75 25 Z',
-    'M75 25 L50 50 L50 0 Z',
-    'M100 50 L50 0 L75 25 Z',
-    'M100 50 L75 25 L50 50 L75 75 Z',
-    'M75 75 L50 50 L100 50 Z',
-    'M50 100 L100 50 L75 75 Z',
-    'M50 100 L75 75 L50 50 L25 75 Z',
-    'M25 75 L50 50 L50 100 Z',
-    'M0 50 L25 75 L50 100 Z',
-    'M0 50 L25 25 L50 50 L25 75 Z',
-    'M25 25 L50 50 L0 50 Z',
-    'M50 0 L0 50 L25 25 Z',
+    'M0.5 0 L0.25 0.25 L0.5 0.5 L0.75 0.25 Z',
+    'M0.75 0.25 L0.5 0.5 L0.5 0 Z',
+    'M1 0.5 L0.5 0 L0.75 0.25 Z',
+    'M1 0.5 L0.75 0.25 L0.5 0.5 L0.75 0.75 Z',
+    'M0.75 0.75 L0.5 0.5 L1 0.5 Z',
+    'M0.5 1 L1 0.5 L0.75 0.75 Z',
+    'M0.5 1 L0.75 0.75 L0.5 0.5 L0.25 0.75 Z',
+    'M0.25 0.75 L0.5 0.5 L0.5 1 Z',
+    'M0 0.5 L0.25 0.75 L0.5 1 Z',
+    'M0 0.5 L0.25 0.25 L0.5 0.5 L0.25 0.75 Z',
+    'M0.25 0.25 L0.5 0.5 L0 0.5 Z',
+    'M0.5 0 L0 0.5 L0.25 0.25 Z',
   ];
   assert.deepStrictEqual(
     HOUSE_POLYGONS.map((p) => p.d),

--- a/tests/sign-labels.test.js
+++ b/tests/sign-labels.test.js
@@ -33,7 +33,7 @@ test('renderNorthIndian defaults to numeric sign labels', () => {
   const svg = new Element('svg');
   renderNorthIndian(svg, { ascSign: 0, signInHouse, planets: [] });
   const texts = svg.children.filter(
-    (c) => c.tagName === 'text' && c.attributes['font-size'] === '4'
+    (c) => c.tagName === 'text' && c.attributes['font-size'] === '0.04'
   );
   const labels = texts.map((t) => t.textContent);
   assert.deepStrictEqual(labels, ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']);
@@ -49,7 +49,7 @@ test('renderNorthIndian can use abbreviated sign labels', () => {
     useAbbreviations: true,
   });
   const texts = svg.children.filter(
-    (c) => c.tagName === 'text' && c.attributes['font-size'] === '4'
+    (c) => c.tagName === 'text' && c.attributes['font-size'] === '0.04'
   );
   const labels = texts.map((t) => t.textContent);
   assert.deepStrictEqual(labels, ['Ar', 'Ta', 'Ge', 'Cn', 'Le', 'Vi', 'Li', 'Sc', 'Sg', 'Cp', 'Aq', 'Pi']);


### PR DESCRIPTION
## Summary
- refactor geometry helpers to output unit-square coordinates
- scale chart rendering by desired size and adjust SVG viewBox
- update tests for normalized paths and labels

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2863aef70832bba0105fae453b86a