### PR TITLE
Refactor chart rendering to use shared paths and computed centroids

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -1,6 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { CHART_PATHS, HOUSE_POLYGONS, getSignLabel } from '../lib/astro.js';
+import {
+  CHART_PATHS,
+  HOUSE_POLYGONS,
+  getSignLabel,
+  polygonCentroid,
+} from '../lib/astro.js';
 
 export default function Chart({ data, children, useAbbreviations = false }) {
   if (
@@ -49,7 +54,8 @@ export default function Chart({ data, children, useAbbreviations = false }) {
           ))}
           <path d={CHART_PATHS.inner} strokeWidth={0.01} />
         </svg>
-        {HOUSE_POLYGONS.map(({ cx, cy }, idx) => {
+        {HOUSE_POLYGONS.map((poly, idx) => {
+          const { cx, cy } = polygonCentroid(poly);
           const houseNum = idx + 1;
           const signIdx = signInHouse[houseNum];
           return (

--- a/tests/chart-orientation-ascendant.test.js
+++ b/tests/chart-orientation-ascendant.test.js
@@ -26,6 +26,12 @@ class Element {
 
 const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
+const centroid = (pts) => {
+  const [sx, sy] = pts.reduce((a, [x, y]) => [a[0] + x, a[1] + y], [0, 0]);
+  const n = pts.length;
+  return { cx: sx / n, cy: sy / n };
+};
+
 test('renderNorthIndian and Chart orient Aries ascendant clockwise', () => {
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) signInHouse[h] = h - 1;
@@ -44,9 +50,10 @@ test('renderNorthIndian and Chart orient Aries ascendant clockwise', () => {
   for (let i = 0; i < 12; i++) {
     const t = houseTexts.find((ht) => ht.textContent === String(i + 1));
     assert.ok(t, `house ${i + 1} missing`);
-    const expected = HOUSE_POLYGONS[i];
-    assert.strictEqual(Number(t.attributes.x), expected.cx);
-    assert.strictEqual(Number(t.attributes.y), expected.cy - 0.06);
+    const poly = HOUSE_POLYGONS[i];
+    const { cx, cy } = centroid(poly);
+    assert.strictEqual(Number(t.attributes.x), cx);
+    assert.strictEqual(Number(t.attributes.y), cy - 0.06);
   }
   delete global.document;
 

--- a/tests/chart-render.test.js
+++ b/tests/chart-render.test.js
@@ -1,10 +1,6 @@
 const assert = require('node:assert');
 const test = require('node:test');
-const {
-  renderNorthIndian,
-  diamondPath,
-  HOUSE_POLYGONS,
-} = require('../src/lib/astro.js');
+const { renderNorthIndian, CHART_PATHS } = require('../src/lib/astro.js');
 
 class Element {
   constructor(tag) {
@@ -30,7 +26,7 @@ class Element {
 
 const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
-test('North Indian chart uses single outer diamond with internal grid', () => {
+test('North Indian chart uses one outer square and internal grid', () => {
   const svg = new Element('svg');
   global.document = doc;
   const signInHouse = [null];
@@ -38,13 +34,15 @@ test('North Indian chart uses single outer diamond with internal grid', () => {
   renderNorthIndian(svg, { ascSign: 0, signInHouse, planets: [] });
 
   const paths = svg.children.filter((c) => c.tagName === 'path');
-  assert.strictEqual(paths.length, 13);
-  assert.strictEqual(paths[0].attributes.d, diamondPath(0.5, 0.5, 0.5));
+  assert.strictEqual(paths.length, 4);
+  assert.strictEqual(paths[0].attributes.d, CHART_PATHS.outer);
   assert.strictEqual(paths[0].attributes['stroke-width'], '0.02');
-  for (let i = 0; i < 12; i++) {
-    assert.strictEqual(paths[i + 1].attributes['stroke-width'], '0.01');
-    assert.strictEqual(paths[i + 1].attributes.d, HOUSE_POLYGONS[i].d);
-  }
+  assert.strictEqual(paths[1].attributes.d, CHART_PATHS.diagonals[0]);
+  assert.strictEqual(paths[2].attributes.d, CHART_PATHS.diagonals[1]);
+  assert.strictEqual(paths[1].attributes['stroke-width'], '0.01');
+  assert.strictEqual(paths[2].attributes['stroke-width'], '0.01');
+  assert.strictEqual(paths[3].attributes.d, CHART_PATHS.inner);
+  assert.strictEqual(paths[3].attributes['stroke-width'], '0.01');
   assert.ok(svg.children.every((el) => el.tagName !== 'line'));
   delete global.document;
 });

--- a/tests/house-polygons.test.js
+++ b/tests/house-polygons.test.js
@@ -18,8 +18,7 @@ test('HOUSE_POLYGONS lists fixed paths for the twelve houses', () => {
     'M0.25 0.25 L0.5 0.5 L0 0.5 Z',
     'M0.5 0 L0 0.5 L0.25 0.25 Z',
   ];
-  assert.deepStrictEqual(
-    HOUSE_POLYGONS.map((p) => p.d),
-    expected
-  );
+  const pathFrom = (pts) =>
+    pts.map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x} ${y}`).join(' ') + ' Z';
+  assert.deepStrictEqual(HOUSE_POLYGONS.map(pathFrom), expected);
 });

--- a/tests/reference-case.test.js
+++ b/tests/reference-case.test.js
@@ -1,6 +1,6 @@
 const assert = require('node:assert');
 const test = require('node:test');
-const { computePositions, renderNorthIndian, diamondPath } = require('../src/lib/astro.js');
+const { computePositions, renderNorthIndian } = require('../src/lib/astro.js');
 
 class Element {
   constructor(tag) {
@@ -42,7 +42,7 @@ test('reference charts for Darbhanga on 1982-12-01 match expected placements', a
   renderNorthIndian(svgAm, am);
   assert.strictEqual(
     svgAm.children.filter((c) => c.tagName === 'path').length,
-    13
+    4
   );
 
   const pm = await computePositions('1982-12-01T15:50+05:30', 26.152, 85.897);
@@ -57,7 +57,7 @@ test('reference charts for Darbhanga on 1982-12-01 match expected placements', a
   renderNorthIndian(svgPm, pm);
   assert.strictEqual(
     svgPm.children.filter((c) => c.tagName === 'path').length,
-    13
+    4
   );
   delete global.document;
 });


### PR DESCRIPTION
## Summary
- Render chart grid with one outer square, two diagonals and a midpoint diamond
- Derive house label positions by averaging polygon vertices
- Align imperative renderer and tests with new geometry

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b287c13c0c832ba734eb3a049083a2