### PR TITLE
Precompute cell centroids for charts

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import {
   CHART_PATHS,
   HOUSE_POLYGONS,
+  HOUSE_CENTROIDS,
   getSignLabel,
-  polygonCentroid,
 } from '../lib/astro.js';
 
 export default function Chart({ data, children, useAbbreviations = false }) {
@@ -54,8 +54,8 @@ export default function Chart({ data, children, useAbbreviations = false }) {
           ))}
           <path d={CHART_PATHS.inner} strokeWidth={0.01} />
         </svg>
-        {HOUSE_POLYGONS.map((poly, idx) => {
-          const { cx, cy } = polygonCentroid(poly);
+        {HOUSE_POLYGONS.map((_, idx) => {
+          const { cx, cy } = HOUSE_CENTROIDS[idx];
           const houseNum = idx + 1;
           const signIdx = signInHouse[houseNum];
           return (

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -77,6 +77,7 @@ function buildHouseGeometry(scale = 1) {
       .join(' ') + ' Z';
 
   const cells = [];
+  const centroids = [];
   for (let i = 0; i < 4; i++) {
     const p0 = mid[i];
     const pCW = inter[i].cw;
@@ -85,12 +86,15 @@ function buildHouseGeometry(scale = 1) {
 
     const kite = i === 3 ? [p0, pCW, O, pCCW] : [p0, pCCW, O, pCW];
     cells.push(kite);
+    centroids.push(polygonCentroid(kite));
 
     const triSide = [pCW, O, p0];
     cells.push(triSide);
+    centroids.push(polygonCentroid(triSide));
 
     const triCorner = i === 2 ? [pNext, pCW, p0] : [pNext, p0, pCW];
     cells.push(triCorner);
+    centroids.push(polygonCentroid(triCorner));
   }
 
   const outer = pathFrom(mid);
@@ -105,10 +109,14 @@ function buildHouseGeometry(scale = 1) {
     `M${mid[3][0] * scale} ${mid[3][1] * scale} L${mid[1][0] * scale} ${mid[1][1] * scale}`,
   ];
 
-  return { paths: { outer, inner, diagonals }, polys: cells };
+  return { paths: { outer, inner, diagonals }, polys: cells, centroids };
 }
 
-export const { paths: CHART_PATHS, polys: HOUSE_POLYGONS } = buildHouseGeometry();
+export const {
+  paths: CHART_PATHS,
+  polys: HOUSE_POLYGONS,
+  centroids: HOUSE_CENTROIDS,
+} = buildHouseGeometry();
 
 export function polygonCentroid(pts) {
   const [sx, sy] = pts.reduce((a, [x, y]) => [a[0] + x, a[1] + y], [0, 0]);
@@ -221,8 +229,7 @@ export function renderNorthIndian(svgEl, data, options = {}) {
   addPath(CHART_PATHS.inner, '0.01');
 
   for (let h = 1; h <= 12; h++) {
-    const poly = HOUSE_POLYGONS[h - 1];
-    const { cx, cy } = polygonCentroid(poly);
+    const { cx, cy } = HOUSE_CENTROIDS[h - 1];
     const signIdx = data.signInHouse?.[h] ?? h - 1;
 
     const hText = document.createElementNS(svgNS, 'text');


### PR DESCRIPTION
## Summary
- precompute cell centroids when building North Indian chart geometry
- expose `HOUSE_CENTROIDS` alongside `HOUSE_POLYGONS`
- position labels in `Chart.jsx` using the precalculated centroids

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b288e407d0832b84b0df62173b949c