### PR TITLE
Add geometry test for house grid

### DIFF
--- a/tests/geometry.test.js
+++ b/tests/geometry.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { HOUSE_POLYGONS } = require('../src/lib/astro.js');
+
+test('build house grid with 12 valid, non-overlapping cells', () => {
+  const cells = HOUSE_POLYGONS;
+  assert.strictEqual(cells.length, 12);
+
+  const seen = new Set();
+  cells.forEach((poly, idx) => {
+    // ensure each vertex is finite and within bounds
+    poly.forEach(([x, y]) => {
+      assert.ok(Number.isFinite(x) && Number.isFinite(y), `cell ${idx} has invalid vertex`);
+      assert.ok(x >= 0 && x <= 1 && y >= 0 && y <= 1, `cell ${idx} vertex out of bounds`);
+    });
+
+    // ensure this polygon hasn't been seen before (non-overlapping)
+    const key = poly.map(([x, y]) => `${x},${y}`).join(';');
+    assert.ok(!seen.has(key), `cell ${idx} overlaps with another cell`);
+    seen.add(key);
+  });
+
+  // TODO: extend with more adjacency checks
+});


### PR DESCRIPTION
## Summary
- add geometry test ensuring house grid builds 12 distinct cells with valid vertices

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b28a5a6cfc832b9e79ebca8490ba18