### PR TITLE
Use area-weighted polygon centroids

### DIFF
--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -128,9 +128,27 @@ export const {
 } = buildHouseGeometry();
 
 export function polygonCentroid(pts) {
-  const [sx, sy] = pts.reduce((a, [x, y]) => [a[0] + x, a[1] + y], [0, 0]);
+  // Compute the centroid using the area-weighted formula (shoelace theorem).
+  // This provides the true geometric centre even for irregular polygons.
+  let doubleArea = 0;
+  let cx = 0;
+  let cy = 0;
   const n = pts.length;
-  return { cx: sx / n, cy: sy / n };
+  for (let i = 0; i < n; i++) {
+    const [x0, y0] = pts[i];
+    const [x1, y1] = pts[(i + 1) % n];
+    const cross = x0 * y1 - x1 * y0;
+    doubleArea += cross;
+    cx += (x0 + x1) * cross;
+    cy += (y0 + y1) * cross;
+  }
+  if (doubleArea === 0) {
+    // Degenerate polygon; fall back to simple average.
+    const [sx, sy] = pts.reduce((a, [x, y]) => [a[0] + x, a[1] + y], [0, 0]);
+    return { cx: sx / n, cy: sy / n };
+  }
+  const area = doubleArea / 2;
+  return { cx: cx / (6 * area), cy: cy / (6 * area) };
 }
 
 export function diamondPath(cx, cy, size = BOX_SIZE) {

--- a/tests/chart-orientation-ascendant.test.js
+++ b/tests/chart-orientation-ascendant.test.js
@@ -27,9 +27,25 @@ class Element {
 const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
 const centroid = (pts) => {
-  const [sx, sy] = pts.reduce((a, [x, y]) => [a[0] + x, a[1] + y], [0, 0]);
+  // Area-weighted centroid using the shoelace formula to mirror the library logic.
+  let doubleArea = 0;
+  let cx = 0;
+  let cy = 0;
   const n = pts.length;
-  return { cx: sx / n, cy: sy / n };
+  for (let i = 0; i < n; i++) {
+    const [x0, y0] = pts[i];
+    const [x1, y1] = pts[(i + 1) % n];
+    const cross = x0 * y1 - x1 * y0;
+    doubleArea += cross;
+    cx += (x0 + x1) * cross;
+    cy += (y0 + y1) * cross;
+  }
+  if (doubleArea === 0) {
+    const [sx, sy] = pts.reduce((a, [x, y]) => [a[0] + x, a[1] + y], [0, 0]);
+    return { cx: sx / n, cy: sy / n };
+  }
+  const area = doubleArea / 2;
+  return { cx: cx / (6 * area), cy: cy / (6 * area) };
 };
 
 test('renderNorthIndian and Chart orient Aries ascendant clockwise', () => {


### PR DESCRIPTION
## Summary
- compute true area-weighted centroids for house polygons
- update orientation tests to use the new centroid algorithm

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2915472c8832b958718c530b08297