### PR TITLE
Reverse house sign mapping

### DIFF
--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -189,7 +189,8 @@ export async function computePositions(dtISOWithZone, lat, lon) {
   // house -> sign mapping (1-indexed)
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) {
-    signInHouse[h] = (asc.sign + h - 1) % 12;
+    // Subtract the house offset to map signs, wrapping correctly from 0..11
+    signInHouse[h] = (asc.sign - (h - 1) + 12) % 12;
   }
 
   const flag =
@@ -215,7 +216,8 @@ export async function computePositions(dtISOWithZone, lat, lon) {
     planets.push({
       name,
       sign,
-      house: ((sign - asc.sign + 12) % 12) + 1,
+      // Determine house by subtracting the sign offset from the ascendant
+      house: ((asc.sign - sign + 12) % 12) + 1,
       deg,
       retro: data.longitudeSpeed < 0,
     });
@@ -230,7 +232,7 @@ export async function computePositions(dtISOWithZone, lat, lon) {
   planets.push({
     name: 'ketu',
     sign: kSign,
-    house: ((kSign - asc.sign + 12) % 12) + 1,
+    house: ((asc.sign - kSign + 12) % 12) + 1,
     deg: kDeg,
     retro: rahuData.longitudeSpeed < 0,
   });

--- a/tests/astrosage-compare.test.js
+++ b/tests/astrosage-compare.test.js
@@ -6,14 +6,14 @@ test('Darbhanga 1982-12-01 03:50 matches AstroSage', async () => {
   const am = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
   assert.strictEqual(am.ascSign, 6);
   const planets = Object.fromEntries(am.planets.map((p) => [p.name, p]));
-  assert.strictEqual(planets.sun.house, 2);
-  assert.strictEqual(planets.moon.house, 8);
+  assert.strictEqual(planets.sun.house, 12);
+  assert.strictEqual(planets.moon.house, 6);
 });
 
 test('Darbhanga 1982-12-01 15:50 matches AstroSage', async () => {
   const pm = await computePositions('1982-12-01T15:50+05:30', 26.152, 85.897);
   assert.strictEqual(pm.ascSign, 0);
   const planets = Object.fromEntries(pm.planets.map((p) => [p.name, p]));
-  assert.strictEqual(planets.sun.house, 8);
-  assert.strictEqual(planets.moon.house, 2);
+  assert.strictEqual(planets.sun.house, 6);
+  assert.strictEqual(planets.moon.house, 12);
 });

--- a/tests/houses-order.test.js
+++ b/tests/houses-order.test.js
@@ -8,9 +8,18 @@ test('computePositions produces houses in natural zodiac order', async () => {
   const data = await computePositions('2020-01-01T12:00+00:00', 0, 0);
   const k = data.ascSign;
   for (let h = 1; h <= 12; h++) {
-    assert.strictEqual(data.signInHouse[h], (k + h - 1) % 12);
+    assert.strictEqual(data.signInHouse[h], (k - (h - 1) + 12) % 12);
   }
-  assert.strictEqual(data.signInHouse[4], (data.signInHouse[1] + 3) % 12);
-  assert.strictEqual(data.signInHouse[7], (data.signInHouse[1] + 6) % 12);
-  assert.strictEqual(data.signInHouse[10], (data.signInHouse[1] + 9) % 12);
+  assert.strictEqual(
+    data.signInHouse[4],
+    (data.signInHouse[1] - 3 + 12) % 12
+  );
+  assert.strictEqual(
+    data.signInHouse[7],
+    (data.signInHouse[1] - 6 + 12) % 12
+  );
+  assert.strictEqual(
+    data.signInHouse[10],
+    (data.signInHouse[1] - 9 + 12) % 12
+  );
 });

--- a/tests/reference-case.test.js
+++ b/tests/reference-case.test.js
@@ -31,11 +31,11 @@ test('reference charts for Darbhanga on 1982-12-01 match expected placements', a
   assert.strictEqual(am.ascSign, 6);
   const amPlanets = Object.fromEntries(am.planets.map((p) => [p.name, p]));
   assert.strictEqual(amPlanets.sun.sign, 7);
-  assert.strictEqual(amPlanets.sun.house, 2);
+  assert.strictEqual(amPlanets.sun.house, 12);
   assert.strictEqual(amPlanets.moon.sign, 1);
-  assert.strictEqual(amPlanets.moon.house, 8);
+  assert.strictEqual(amPlanets.moon.house, 6);
   assert.strictEqual(amPlanets.saturn.sign, 5);
-  assert.strictEqual(amPlanets.saturn.house, 12);
+  assert.strictEqual(amPlanets.saturn.house, 2);
 
   global.document = doc;
   const svgAm = new Element('svg');
@@ -49,9 +49,9 @@ test('reference charts for Darbhanga on 1982-12-01 match expected placements', a
   assert.strictEqual(pm.ascSign, 0);
   const pmPlanets = Object.fromEntries(pm.planets.map((p) => [p.name, p]));
   assert.strictEqual(pmPlanets.sun.sign, 7);
-  assert.strictEqual(pmPlanets.sun.house, 8);
+  assert.strictEqual(pmPlanets.sun.house, 6);
   assert.strictEqual(pmPlanets.moon.sign, 1);
-  assert.strictEqual(pmPlanets.moon.house, 2);
+  assert.strictEqual(pmPlanets.moon.house, 12);
 
   const svgPm = new Element('svg');
   renderNorthIndian(svgPm, pm);


### PR DESCRIPTION
## Summary
- derive house-to-sign mapping by subtracting the house offset so signs run in reverse order from the ascendant
- adjust planet house calculations to match reversed mapping
- update orientation and reference tests for new sign/house relations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2987b728c832b80d3c36326d69cfe