### PR TITLE
style: make house containers flex and responsive

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -61,35 +61,33 @@ export default function Chart({ data, children, useAbbreviations = false }) {
           return (
             <div
               key={houseNum}
-              className="absolute w-[60px] h-[60px] overflow-hidden whitespace-nowrap text-center"
+              className="absolute flex flex-col justify-center items-center text-center overflow-hidden w-[60px] h-[60px] min-w-[50px] min-h-[50px] text-xs gap-[2px] p-[2px]"
               style={{
                 top: cy * size,
                 left: cx * size,
                 transform: 'translate(-50%, -50%)',
               }}
             >
-              <div className="flex flex-col items-center text-xs gap-[2px] p-[2px] w-full h-full">
-                <span className="text-yellow-300/40 text-[0.6rem] leading-none">
-                  {houseNum}
+              <span className="text-yellow-300/40 text-[0.6rem] leading-none">
+                {houseNum}
+              </span>
+              {houseNum === 1 && (
+                <span className="text-yellow-300 text-[0.6rem] leading-none">
+                  La/Asc
                 </span>
-                {houseNum === 1 && (
-                  <span className="text-yellow-300 text-[0.6rem] leading-none">
-                    La/Asc
+              )}
+              <span className="text-orange-300 font-semibold text-[clamp(0.5rem,0.8vw,0.75rem)]">
+                {getSignLabel(signIdx, { useAbbreviations })}
+              </span>
+              {planetBySign[signIdx] &&
+                planetBySign[signIdx].map((pl, i) => (
+                  <span
+                    key={i}
+                    className="px-[2px] text-[clamp(0.5rem,0.7vw,0.75rem)]"
+                  >
+                    {pl}
                   </span>
-                )}
-                <span className="text-orange-300 font-semibold text-[clamp(0.5rem,0.8vw,0.75rem)]">
-                  {getSignLabel(signIdx, { useAbbreviations })}
-                </span>
-                {planetBySign[signIdx] &&
-                  planetBySign[signIdx].map((pl, i) => (
-                    <span
-                      key={i}
-                      className="px-[2px] text-[clamp(0.5rem,0.7vw,0.75rem)]"
-                    >
-                      {pl}
-                    </span>
-                  ))}
-              </div>
+                ))}
             </div>
           );
         })}


### PR DESCRIPTION
## Summary
- convert house overlays to flex containers with centered layout
- drop whitespace wrapping and use gap spacing
- add minimum sizing to prevent text overlap

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b299418654832bbd437c3fe4064f13