### PR TITLE
Fix house to chart position mapping

### DIFF
--- a/tests/chart-orientation-ascendant.test.js
+++ b/tests/chart-orientation-ascendant.test.js
@@ -1,6 +1,10 @@
 const assert = require('node:assert');
 const test = require('node:test');
-const { renderNorthIndian, HOUSE_POLYGONS } = require('../src/lib/astro.js');
+const {
+  renderNorthIndian,
+  HOUSE_POLYGONS,
+  HOUSE_CENTROIDS,
+} = require('../src/lib/astro.js');
 
 class Element {
   constructor(tag) {
@@ -26,27 +30,6 @@ class Element {
 
 const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
-const centroid = (pts) => {
-  // Area-weighted centroid using the shoelace formula to mirror the library logic.
-  let doubleArea = 0;
-  let cx = 0;
-  let cy = 0;
-  const n = pts.length;
-  for (let i = 0; i < n; i++) {
-    const [x0, y0] = pts[i];
-    const [x1, y1] = pts[(i + 1) % n];
-    const cross = x0 * y1 - x1 * y0;
-    doubleArea += cross;
-    cx += (x0 + x1) * cross;
-    cy += (y0 + y1) * cross;
-  }
-  if (doubleArea === 0) {
-    const [sx, sy] = pts.reduce((a, [x, y]) => [a[0] + x, a[1] + y], [0, 0]);
-    return { cx: sx / n, cy: sy / n };
-  }
-  const area = doubleArea / 2;
-  return { cx: cx / (6 * area), cy: cy / (6 * area) };
-};
 
 test('renderNorthIndian and Chart orient Aries ascendant clockwise', () => {
   const signInHouse = [null];
@@ -66,8 +49,7 @@ test('renderNorthIndian and Chart orient Aries ascendant clockwise', () => {
   for (let i = 0; i < 12; i++) {
     const t = houseTexts.find((ht) => ht.textContent === String(i + 1));
     assert.ok(t, `house ${i + 1} missing`);
-    const poly = HOUSE_POLYGONS[i];
-    const { cx, cy } = centroid(poly);
+    const { cx, cy } = HOUSE_CENTROIDS[i];
     assert.strictEqual(Number(t.attributes.x), cx);
     assert.strictEqual(Number(t.attributes.y), cy - 0.06);
   }

--- a/tests/house-polygons.test.js
+++ b/tests/house-polygons.test.js
@@ -1,24 +1,18 @@
 const test = require('node:test');
 const assert = require('node:assert');
-const { HOUSE_POLYGONS } = require('../src/lib/astro.js');
+const {
+  HOUSE_POLYGONS,
+  HOUSE_CENTROIDS,
+  polygonCentroid,
+} = require('../src/lib/astro.js');
 
-test('HOUSE_POLYGONS lists fixed paths for the twelve houses', () => {
+test('HOUSE_POLYGONS exposes 12 regions with expected centroids', () => {
   assert.strictEqual(HOUSE_POLYGONS.length, 12);
-  const expected = [
-    'M0 0 L0.5 0 L1 0 L1 0.5 L0.5 0.5 L0 0.5 Z',
-    'M0 0 L0.5 0.5 L0 0.5 Z',
-    'M0 0 L0.5 0 L0.5 0.5 Z',
-    'M0 1 L0 0.5 L0 0 L0.5 0 L0.5 0.5 L0.5 1 Z',
-    'M0 1 L0.5 0.5 L0.5 1 Z',
-    'M0 1 L0 0.5 L0.5 0.5 Z',
-    'M1 1 L0.5 1 L0 1 L0 0.5 L0.5 0.5 L1 0.5 Z',
-    'M1 1 L0.5 0.5 L1 0.5 Z',
-    'M1 1 L0.5 1 L0.5 0.5 Z',
-    'M1 0 L1 0.5 L1 1 L0.5 1 L0.5 0.5 L0.5 0 Z',
-    'M1 0 L0.5 0.5 L0.5 0 Z',
-    'M1 0 L1 0.5 L0.5 0.5 Z',
-  ];
-  const pathFrom = (pts) =>
-    pts.map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x} ${y}`).join(' ') + ' Z';
-  assert.deepStrictEqual(HOUSE_POLYGONS.map(pathFrom), expected);
+  HOUSE_POLYGONS.forEach((poly, i) => {
+    assert.ok(poly.length >= 3);
+    const { cx, cy } = polygonCentroid(poly);
+    const expected = HOUSE_CENTROIDS[i];
+    assert.ok(Math.abs(cx - expected.cx) < 1e-9);
+    assert.ok(Math.abs(cy - expected.cy) < 1e-9);
+  });
 });


### PR DESCRIPTION
## Summary
- ensure each house renders in its correct chart cell
- replace house polygon layout with ordered centroid mapping
- adjust tests for new mapping

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2a813b090832b9621d72ba6e287b7