### PR TITLE
Render planet info in single span

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -121,10 +121,9 @@ export default function Chart({ data, children, useAbbreviations = false }) {
 
                 {planetBySign[signIdx] &&
                   planetBySign[signIdx].map((pl, i) => (
-                    <div key={i} className="flex flex-col items-center">
-                      <span>{pl.abbr}</span>
-                      <span>{pl.deg}</span>
-                    </div>
+                    <span key={i} className="text-center">
+                      {pl.abbr} {pl.deg}
+                    </span>
                   ))}
               </div>
             </div>


### PR DESCRIPTION
## Summary
- Simplify planet display in Chart by combining abbreviation and degree into one span

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2c18aaf90832bb6807d2b859e4387