### PR TITLE
fix: change Asc label

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -114,7 +114,7 @@ export default function Chart({ data, children, useAbbreviations = false }) {
                 {houseNum === 1 && (
                   <div className="flex flex-col items-center">
                     <span className="text-yellow-300 text-[0.6rem] leading-none">
-                      La/Asc
+                      Asc
                     </span>
                   </div>
                 )}


### PR DESCRIPTION
## Summary
- update Chart component to display `Asc` instead of `La/Asc`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2c237d968832bb12c56a87ee382b9