### PR TITLE
Derive chart house centroids from geometry

### DIFF
--- a/tests/text-inside-polygons.test.js
+++ b/tests/text-inside-polygons.test.js
@@ -1,0 +1,72 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const {
+  renderNorthIndian,
+  HOUSE_POLYGONS,
+} = require('../src/lib/astro.js');
+
+class Element {
+  constructor(tag) {
+    this.tagName = tag;
+    this.attributes = {};
+    this.children = [];
+    this.textContent = '';
+  }
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+  }
+  appendChild(child) {
+    this.children.push(child);
+  }
+  removeChild(child) {
+    const i = this.children.indexOf(child);
+    if (i >= 0) this.children.splice(i, 1);
+  }
+  get firstChild() {
+    return this.children[0];
+  }
+}
+
+const doc = { createElementNS: (ns, tag) => new Element(tag) };
+
+function pointInPolygon(x, y, poly) {
+  let inside = false;
+  for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+    const [xi, yi] = poly[i];
+    const [xj, yj] = poly[j];
+    const intersect = yi > y !== yj > y && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi;
+    if (intersect) inside = !inside;
+  }
+  return inside;
+}
+
+test('all text elements render inside their house polygons', () => {
+  const signInHouse = [null];
+  for (let h = 1; h <= 12; h++) signInHouse[h] = h - 1;
+  const planets = Array.from({ length: 12 }, (_, i) => ({ name: `p${i}`, sign: i, deg: 0 }));
+  const data = { ascSign: 0, signInHouse, planets };
+
+  global.document = doc;
+  const svg = new Element('svg');
+  renderNorthIndian(svg, data);
+  delete global.document;
+
+  const texts = svg.children.filter((c) => c.tagName === 'text');
+  texts.forEach((t) => {
+    const x = Number(t.attributes.x);
+    const y = Number(t.attributes.y);
+    const house = HOUSE_POLYGONS.findIndex((poly) => pointInPolygon(x, y, poly)) + 1;
+    assert.ok(house > 0, `text \\"${t.textContent}\\" not inside any house`);
+
+    if (t.textContent === 'Asc') {
+      assert.strictEqual(house, 1);
+    } else if (/^\d+$/.test(t.textContent)) {
+      const num = Number(t.textContent);
+      assert.strictEqual(house, num);
+    } else if (/^p\d+/.test(t.textContent)) {
+      const idx = Number(t.textContent.match(/^p(\d+)/)[1]);
+      assert.strictEqual(house, idx + 1);
+    }
+  });
+});
+


### PR DESCRIPTION
## Summary
- compute North-Indian chart house polygons from CHART_PATHS and derive their centroids
- use geometric centroids for rendering and adjust planet label spacing to remain inside houses
- add rendering test ensuring every <text> element lies within its house polygon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2d8693858832b957d58d8d63e10f1