### PR TITLE
test: update Darbhanga placements to Libra

### DIFF
--- a/tests/astrosage-compare.test.js
+++ b/tests/astrosage-compare.test.js
@@ -5,23 +5,41 @@ const { computePositions } = require('../src/lib/astro.js');
 test('Darbhanga 1982-12-01 03:50 matches AstroSage', async () => {
   const am = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
   assert.strictEqual(am.ascSign, 6);
+
   const planets = Object.fromEntries(am.planets.map((p) => [p.name, p]));
-  assert.deepStrictEqual(
-    am.planets.filter((p) => p.house === 7).map((p) => p.name),
-    ['mercury', 'venus']
-  );
-  assert.strictEqual(planets.sun.house, 2);
-  assert.strictEqual(planets.moon.house, 8);
-  assert.strictEqual(planets.jupiter.house, 2);
-  assert.strictEqual(planets.saturn.house, 1);
+  const expected = {
+    sun: 2,
+    moon: 8,
+    mars: 6,
+    mercury: 7,
+    jupiter: 2,
+    venus: 7,
+    saturn: 1,
+    rahu: 9,
+    ketu: 3,
+  };
+  for (const [name, house] of Object.entries(expected)) {
+    assert.strictEqual(planets[name].house, house, `${name} house`);
+  }
 });
 
 test('Darbhanga 1982-12-01 15:50 matches AstroSage', async () => {
   const pm = await computePositions('1982-12-01T15:50+05:30', 26.152, 85.897);
   assert.strictEqual(pm.ascSign, 1);
+
   const planets = Object.fromEntries(pm.planets.map((p) => [p.name, p]));
-  assert.strictEqual(planets.sun.house, 7);
-  assert.strictEqual(planets.moon.house, 1);
-  assert.strictEqual(planets.jupiter.house, 7);
-  assert.strictEqual(planets.saturn.house, 6);
+  const expected = {
+    sun: 7,
+    moon: 1,
+    mars: 11,
+    mercury: 12,
+    jupiter: 7,
+    venus: 12,
+    saturn: 6,
+    rahu: 2,
+    ketu: 8,
+  };
+  for (const [name, house] of Object.entries(expected)) {
+    assert.strictEqual(planets[name].house, house, `${name} house`);
+  }
 });


### PR DESCRIPTION
## Summary
- assert Darbhanga 1982-12-01 03:50 chart uses Libra ascendant and correct planet houses
- verify 15:50 chart houses through a single expectation map

## Testing
- `node --test tests/astrosage-compare.test.js` (fails before fix)
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68b2f404abc0832ba2798a98fbb828a7