### PR TITLE
Render planets by house for chart rendering

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -46,10 +46,10 @@ export default function Chart({ data, children, useAbbreviations = false }) {
   }
   const signInHouse = data.signInHouse;
 
-  const planetBySign = {};
+  const planetByHouse = {};
   data.planets.forEach((p) => {
-    const signIdx = p.sign;
-    if (signIdx === undefined) return;
+    const houseIdx = p.house;
+    if (houseIdx === undefined) return;
     const degreeValue = Number(p.deg ?? p.degree);
     let degree = 'No data';
     if (!Number.isNaN(degreeValue)) {
@@ -62,8 +62,8 @@ export default function Chart({ data, children, useAbbreviations = false }) {
     if (p.combust) abbr += '(C)';
     if (p.exalted) abbr += '(Ex)';
     const deg = degree;
-    planetBySign[signIdx] = planetBySign[signIdx] || [];
-    planetBySign[signIdx].push({ abbr, deg });
+    planetByHouse[houseIdx] = planetByHouse[houseIdx] || [];
+    planetByHouse[houseIdx].push({ abbr, deg });
   });
 
   const size = 300; // chart size
@@ -135,8 +135,8 @@ export default function Chart({ data, children, useAbbreviations = false }) {
                   </div>
                 )}
 
-                {planetBySign[signIdx] &&
-                  planetBySign[signIdx].map((pl, i) => (
+                {planetByHouse[houseNum] &&
+                  planetByHouse[houseNum].map((pl, i) => (
                     <span key={i} className="text-center">
                       {pl.abbr} {pl.deg}
                     </span>
@@ -157,8 +157,8 @@ Chart.propTypes = {
     planets: PropTypes.arrayOf(
       PropTypes.shape({
         name: PropTypes.string.isRequired,
-        sign: PropTypes.number.isRequired,
-        house: PropTypes.number,
+        sign: PropTypes.number,
+        house: PropTypes.number.isRequired,
         deg: PropTypes.number,
         retro: PropTypes.bool,
         combust: PropTypes.bool,

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -247,7 +247,7 @@ export function renderNorthIndian(svgEl, data, options = {}) {
     signText.textContent = getSignLabel(signIdx, options);
     svgEl.appendChild(signText);
 
-    const planets = data.planets.filter((p) => p.sign === signIdx);
+    const planets = data.planets.filter((p) => p.house === h);
     const maxY = Math.max(...poly.map((pt) => pt[1]));
     let py = Math.min(cy + 0.04, maxY - 0.02);
     const step =

--- a/tests/darbhanga-dec-1982.test.js
+++ b/tests/darbhanga-dec-1982.test.js
@@ -1,0 +1,11 @@
+const assert = require('node:assert');
+const test = require('node:test');
+const { computePositions } = require('../src/lib/astro.js');
+
+test('Darbhanga 1982-12-01 03:50 positions', async () => {
+  const res = await computePositions('1982-12-01T03:50+05:30', 26.15216, 85.89707);
+  const planets = Object.fromEntries(res.planets.map((p) => [p.name, p]));
+  assert.strictEqual(planets.moon.house, 8);
+  assert.strictEqual(planets.mars.house, 6);
+  assert.strictEqual(planets.ketu.house, 3);
+});

--- a/tests/text-inside-polygons.test.js
+++ b/tests/text-inside-polygons.test.js
@@ -43,7 +43,12 @@ function pointInPolygon(x, y, poly) {
 test('all text elements render inside their house polygons', () => {
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) signInHouse[h] = h - 1;
-  const planets = Array.from({ length: 12 }, (_, i) => ({ name: `p${i}`, sign: i, deg: 0 }));
+  const planets = Array.from({ length: 12 }, (_, i) => ({
+    name: `p${i}`,
+    sign: i,
+    house: i + 1,
+    deg: 0,
+  }));
   const data = { ascSign: 0, signInHouse, planets };
 
   global.document = doc;


### PR DESCRIPTION
## Summary
- Map planets by their house in Chart component and render `planetByHouse[houseNum]`
- Filter planets by `house` in `renderNorthIndian`
- Add house data to tests and cover Darbhanga 1982-12-01 chart

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b30554dda4832bbe1a50a95f03dc12