### PR TITLE
feat: prevent sign labels from overlapping planets

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -104,6 +104,13 @@ export default function Chart({ data, children, useAbbreviations = false }) {
 
           const labelPos = `${vert} ${horiz}`;
 
+          const padClasses = [
+            vert === 'top-0' ? 'pt-4' : vert === 'bottom-0' ? 'pb-4' : '',
+            horiz === 'left-0' ? 'pl-4' : horiz === 'right-0' ? 'pr-4' : '',
+          ]
+            .filter(Boolean)
+            .join(' ');
+
           const margin = 4; // pixels
           const width = (maxX - minX) * size - margin;
           const height = (maxY - minY) * size - margin;
@@ -126,7 +133,9 @@ export default function Chart({ data, children, useAbbreviations = false }) {
                 {getSignLabel(signIdx, { useAbbreviations })}
               </span>
 
-              <div className="flex flex-col items-center justify-center h-full gap-1 text-amber-900 font-medium text-[clamp(0.55rem,0.75vw,0.85rem)]">
+              <div
+                className={`flex flex-col items-center justify-center h-full gap-1 text-amber-900 font-medium text-[clamp(0.55rem,0.75vw,0.85rem)] ${padClasses}`}
+              >
                 {houseNum === 1 && (
                   <div className="flex flex-col items-center">
                     <span className="text-amber-700 text-[0.7rem] font-semibold leading-none">

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -249,7 +249,7 @@ export function renderNorthIndian(svgEl, data, options = {}) {
 
     const planets = data.planets.filter((p) => p.house === h);
     const maxY = Math.max(...poly.map((pt) => pt[1]));
-    let py = Math.min(cy + 0.04, maxY - 0.02);
+    let py = Math.min(cy + 0.06, maxY - 0.02);
     const step =
       planets.length > 1
         ? Math.min(

--- a/tests/planet-spacing.test.js
+++ b/tests/planet-spacing.test.js
@@ -1,0 +1,57 @@
+const assert = require('node:assert');
+const test = require('node:test');
+const { renderNorthIndian, HOUSE_CENTROIDS } = require('../src/lib/astro.js');
+
+class Element {
+  constructor(tag) {
+    this.tagName = tag;
+    this.attributes = {};
+    this.children = [];
+    this.textContent = '';
+  }
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+  }
+  appendChild(child) {
+    this.children.push(child);
+  }
+  removeChild(child) {
+    const i = this.children.indexOf(child);
+    if (i >= 0) this.children.splice(i, 1);
+  }
+  get firstChild() {
+    return this.children[0];
+  }
+}
+
+const doc = { createElementNS: (ns, tag) => new Element(tag) };
+
+test('planets render in distinct rows below sign label', () => {
+  const signInHouse = [null];
+  for (let h = 1; h <= 12; h++) signInHouse[h] = h - 1;
+  const planets = [
+    { name: 'p1', house: 2, deg: 0 },
+    { name: 'p2', house: 2, deg: 10 },
+    { name: 'p3', house: 2, deg: 20 },
+    { name: 'p4', house: 2, deg: 30 },
+  ];
+
+  global.document = doc;
+  const svg = new Element('svg');
+  renderNorthIndian(svg, { ascSign: 0, signInHouse, planets });
+  delete global.document;
+
+  const { cx, cy } = HOUSE_CENTROIDS[1]; // house 2
+  const texts = svg.children.filter((c) => c.tagName === 'text');
+  const planetYs = texts
+    .filter((t) => Number(t.attributes.x) === cx && t.textContent.startsWith('p'))
+    .map((t) => Number(t.attributes.y));
+
+  assert.strictEqual(planetYs.length, 4);
+  planetYs.forEach((y) => {
+    assert.ok(y >= cy + 0.05, 'planet overlaps sign label');
+  });
+  for (let i = 1; i < planetYs.length; i++) {
+    assert.ok(planetYs[i] - planetYs[i - 1] >= 0.02, 'planet rows overlap');
+  }
+});


### PR DESCRIPTION
## Summary
- add padding around house content so sign labels don't collide with planets
- push planet rows further below sign labels in `renderNorthIndian`
- test rendering multiple planets to confirm spacing remains distinct

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3073117fc832ba12f1902d4562e63