### PR TITLE
Display house numbers in chart

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -136,6 +136,10 @@ export default function Chart({ data, children, useAbbreviations = false }) {
               <div
                 className={`flex flex-col items-center justify-center h-full gap-1 text-amber-900 font-medium text-[clamp(0.55rem,0.75vw,0.85rem)] ${padClasses}`}
               >
+                <span className="text-amber-700 text-[0.7rem] font-semibold leading-none">
+                  {houseNum}
+                </span>
+
                 {houseNum === 1 && (
                   <div className="flex flex-col items-center">
                     <span className="text-amber-700 text-[0.7rem] font-semibold leading-none">


### PR DESCRIPTION
## Summary
- Show each house number in the center of its polygon
- Keep numbering styled similarly to the existing "Asc" label

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b30c150550832bacf429713c806eec