### PR TITLE
Render sign numbers at house centers

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -83,33 +83,13 @@ export default function Chart({ data, children, useAbbreviations = false }) {
           ))}
           <path d={CHART_PATHS.inner} strokeWidth={0.01} />
         </svg>
-        {HOUSE_POLYGONS.map((poly, idx) => {
+        {HOUSE_POLYGONS.map((_, idx) => {
           const bbox = HOUSE_BBOXES[idx];
           const { minX, maxX, minY, maxY } = bbox;
           const bx = (minX + maxX) / 2;
           const by = (minY + maxY) / 2;
           const houseNum = idx + 1;
           const signIdx = signInHouse[houseNum];
-
-          // Determine the inner corner closest to the chart centre (0.5, 0.5)
-          const EPS = 1e-9;
-          let vert, horiz;
-          if (by < 0.5 - EPS) vert = 'bottom-0';
-          else if (by > 0.5 + EPS) vert = 'top-0';
-          else vert = bx < 0.5 ? 'top-0' : 'bottom-0';
-
-          if (bx < 0.5 - EPS) horiz = 'right-0';
-          else if (bx > 0.5 + EPS) horiz = 'left-0';
-          else horiz = by < 0.5 ? 'right-0' : 'left-0';
-
-          const labelPos = `${vert} ${horiz}`;
-
-          const padClasses = [
-            vert === 'top-0' ? 'pt-4' : vert === 'bottom-0' ? 'pb-4' : '',
-            horiz === 'left-0' ? 'pl-4' : horiz === 'right-0' ? 'pr-4' : '',
-          ]
-            .filter(Boolean)
-            .join(' ');
 
           const margin = 4; // pixels
           const width = (maxX - minX) * size - margin;
@@ -127,17 +107,11 @@ export default function Chart({ data, children, useAbbreviations = false }) {
                 transform: 'translate(-50%, -50%)',
               }}
             >
-              <span
-                className={`absolute text-[11px] font-bold text-amber-700/70 ${labelPos}`}
-              >
-                {getSignLabel(signIdx, { useAbbreviations })}
-              </span>
-
               <div
-                className={`flex flex-col items-center justify-center h-full gap-1 text-amber-900 font-medium text-[clamp(0.55rem,0.75vw,0.85rem)] ${padClasses}`}
+                className="flex flex-col items-center justify-center h-full gap-1 text-amber-900 font-medium text-[clamp(0.55rem,0.75vw,0.85rem)]"
               >
                 <span className="text-amber-700 text-[0.7rem] font-semibold leading-none">
-                  {houseNum}
+                  {getSignLabel(signIdx, { useAbbreviations })}
                 </span>
 
                 {houseNum === 1 && (

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -222,14 +222,6 @@ export function renderNorthIndian(svgEl, data, options = {}) {
     const { cx, cy } = HOUSE_CENTROIDS[h - 1];
     const signIdx = data.signInHouse?.[h] ?? h - 1;
 
-    const hText = document.createElementNS(svgNS, 'text');
-    hText.setAttribute('x', cx);
-    hText.setAttribute('y', cy - 0.06);
-    hText.setAttribute('text-anchor', 'middle');
-    hText.setAttribute('font-size', '0.03');
-    hText.textContent = String(h);
-    svgEl.appendChild(hText);
-
     if (h === 1) {
       const ascText = document.createElementNS(svgNS, 'text');
       ascText.setAttribute('x', cx);

--- a/tests/houses-order.test.js
+++ b/tests/houses-order.test.js
@@ -37,19 +37,16 @@ test('houses and signs increase anti-clockwise from ascendant', () => {
   global.document = doc;
   const svg = new Element('svg');
   renderNorthIndian(svg, data);
-  const houseTexts = svg.children.filter(
-    (c) =>
-      c.tagName === 'text' &&
-      c.attributes['font-size'] === '0.03' &&
-      /^\d+$/.test(c.textContent)
+  const signTexts = svg.children.filter(
+    (c) => c.tagName === 'text' && c.attributes['font-size'] === '0.04'
   );
-  assert.strictEqual(houseTexts.length, 12);
+  assert.strictEqual(signTexts.length, 12);
   for (let i = 0; i < 12; i++) {
-    const t = houseTexts.find((ht) => ht.textContent === String(i + 1));
-    assert.ok(t, `house ${i + 1} missing`);
+    const t = signTexts.find((st) => st.textContent === String(i + 1));
+    assert.ok(t, `sign ${i + 1} missing`);
     const { cx, cy } = HOUSE_CENTROIDS[i];
     assert.strictEqual(Number(t.attributes.x), cx);
-    assert.strictEqual(Number(t.attributes.y), cy - 0.06);
+    assert.strictEqual(Number(t.attributes.y), cy);
   }
   delete global.document;
 


### PR DESCRIPTION
## Summary
- Show sign labels at the center of each house and remove corner labels
- Update SVG renderer to emit sign labels in the house centers
- Adjust houses-order test for sign-centered labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b314547ef0832b8f64ebb85a9f6076