### PR TITLE
Center sign numbers in chart

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -107,13 +107,13 @@ export default function Chart({ data, children, useAbbreviations = false }) {
                 transform: 'translate(-50%, -50%)',
               }}
             >
-              <div
-                className="flex flex-col items-center justify-center h-full gap-1 text-amber-900 font-medium text-[clamp(0.55rem,0.75vw,0.85rem)]"
-              >
-                <span className="text-amber-700 text-[0.7rem] font-semibold leading-none">
+              <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+                <span className="text-amber-700 font-bold text-[clamp(0.9rem,1.5vw,1.2rem)] leading-none">
                   {getSignLabel(signIdx, { useAbbreviations })}
                 </span>
+              </div>
 
+              <div className="flex flex-col items-center justify-center h-full gap-1 text-amber-900 font-medium text-[clamp(0.55rem,0.75vw,0.85rem)]">
                 {houseNum === 1 && (
                   <div className="flex flex-col items-center">
                     <span className="text-amber-700 text-[0.7rem] font-semibold leading-none">

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -218,7 +218,6 @@ export function renderNorthIndian(svgEl, data, options = {}) {
   addPath(CHART_PATHS.inner, '0.01');
 
   for (let h = 1; h <= 12; h++) {
-    const poly = HOUSE_POLYGONS[h - 1];
     const { cx, cy } = HOUSE_CENTROIDS[h - 1];
     const signIdx = data.signInHouse?.[h] ?? h - 1;
 
@@ -236,10 +235,11 @@ export function renderNorthIndian(svgEl, data, options = {}) {
     signText.setAttribute('x', cx);
     signText.setAttribute('y', cy);
     signText.setAttribute('text-anchor', 'middle');
-    signText.setAttribute('font-size', '0.04');
+    signText.setAttribute('font-size', '0.05');
     signText.textContent = getSignLabel(signIdx, options);
     svgEl.appendChild(signText);
 
+    const poly = HOUSE_POLYGONS[h - 1];
     const planets = data.planets.filter((p) => p.house === h);
     const maxY = Math.max(...poly.map((pt) => pt[1]));
     let py = Math.min(cy + 0.06, maxY - 0.02);

--- a/tests/houses-order.test.js
+++ b/tests/houses-order.test.js
@@ -38,7 +38,7 @@ test('houses and signs increase anti-clockwise from ascendant', () => {
   const svg = new Element('svg');
   renderNorthIndian(svg, data);
   const signTexts = svg.children.filter(
-    (c) => c.tagName === 'text' && c.attributes['font-size'] === '0.04'
+    (c) => c.tagName === 'text' && c.attributes['font-size'] === '0.05'
   );
   assert.strictEqual(signTexts.length, 12);
   for (let i = 0; i < 12; i++) {

--- a/tests/sign-labels.test.js
+++ b/tests/sign-labels.test.js
@@ -33,7 +33,7 @@ test('renderNorthIndian defaults to numeric sign labels', () => {
   const svg = new Element('svg');
   renderNorthIndian(svg, { ascSign: 0, signInHouse, planets: [] });
   const texts = svg.children.filter(
-    (c) => c.tagName === 'text' && c.attributes['font-size'] === '0.04'
+    (c) => c.tagName === 'text' && c.attributes['font-size'] === '0.05'
   );
   const labels = texts.map((t) => t.textContent);
   assert.deepStrictEqual(labels, ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12']);
@@ -49,7 +49,7 @@ test('renderNorthIndian can use abbreviated sign labels', () => {
     useAbbreviations: true,
   });
   const texts = svg.children.filter(
-    (c) => c.tagName === 'text' && c.attributes['font-size'] === '0.04'
+    (c) => c.tagName === 'text' && c.attributes['font-size'] === '0.05'
   );
   const labels = texts.map((t) => t.textContent);
   assert.deepStrictEqual(labels, ['Ar', 'Ta', 'Ge', 'Cn', 'Le', 'Vi', 'Li', 'Sc', 'Sg', 'Cp', 'Aq', 'Pi']);


### PR DESCRIPTION
## Summary
- Center sign numbers within each house using flex and a bold, larger font
- Place sign labels at polygon centroids in `renderNorthIndian` with increased font size
- Adjust tests to reflect updated sign label font size and confirm anti-clockwise ordering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3182d88ac832b86e9b9ec3e241304