### PR TITLE
feat: switch to 1-based sign numbering

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -89,7 +89,7 @@ export default function Chart({ data, children, useAbbreviations = false }) {
           const bx = (minX + maxX) / 2;
           const by = (minY + maxY) / 2;
           const houseNum = idx + 1;
-          const signIdx = signInHouse[houseNum];
+          const signNum = signInHouse[houseNum];
 
           const margin = 4; // pixels
           const width = (maxX - minX) * size - margin;
@@ -109,7 +109,7 @@ export default function Chart({ data, children, useAbbreviations = false }) {
             >
               <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
                 <span className="text-amber-700 font-bold text-[clamp(0.9rem,1.5vw,1.2rem)] leading-none">
-                  {getSignLabel(signIdx, { useAbbreviations })}
+                  {getSignLabel(signNum - 1, { useAbbreviations })}
                 </span>
               </div>
 

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -143,11 +143,13 @@ export async function computePositions(dtISOWithZone, lat, lon) {
     lon,
   });
 
-  // Derive sign indices for each house from the returned cusp longitudes.
+  // Derive sign numbers (1–12) for each house from the returned cusp
+  // longitudes. Swiss Ephemeris gives cusp longitudes in degrees; we map
+  // these to signs and store them as 1-based values.
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) {
     const lon = base.houses[h];
-    const sign = Math.floor((((lon % 360) + 360) % 360) / 30);
+    const sign = Math.floor((((lon % 360) + 360) % 360) / 30) + 1;
     signInHouse[h] = sign;
   }
   if (process.env.DEBUG_HOUSES) {
@@ -219,7 +221,7 @@ export function renderNorthIndian(svgEl, data, options = {}) {
 
   for (let h = 1; h <= 12; h++) {
     const { cx, cy } = HOUSE_CENTROIDS[h - 1];
-    const signIdx = data.signInHouse?.[h] ?? h - 1;
+    const signNum = data.signInHouse?.[h] ?? h;
 
     if (h === 1) {
       const ascText = document.createElementNS(svgNS, 'text');
@@ -236,7 +238,7 @@ export function renderNorthIndian(svgEl, data, options = {}) {
     signText.setAttribute('y', cy);
     signText.setAttribute('text-anchor', 'middle');
     signText.setAttribute('font-size', '0.05');
-    signText.textContent = getSignLabel(signIdx, options);
+    signText.textContent = getSignLabel(signNum - 1, options);
     svgEl.appendChild(signText);
 
     const poly = HOUSE_POLYGONS[h - 1];

--- a/tests/astroComparison.test.js
+++ b/tests/astroComparison.test.js
@@ -19,7 +19,7 @@ const reference = {
 
 test('computePositions matches AstroSage reference for Darbhanga 1982-12-01 03:50', async () => {
   const result = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
-  assert.strictEqual(result.ascSign, 6);
+  assert.strictEqual(result.ascSign, 7);
   assert.deepStrictEqual(
     result.planets.filter((p) => p.house === 7).map((p) => p.name),
     ['mercury', 'venus']

--- a/tests/astrosage-compare.test.js
+++ b/tests/astrosage-compare.test.js
@@ -4,7 +4,7 @@ const { computePositions } = require('../src/lib/astro.js');
 
 test('Darbhanga 1982-12-01 03:50 matches AstroSage', async () => {
   const am = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
-  assert.strictEqual(am.ascSign, 6);
+  assert.strictEqual(am.ascSign, 7);
 
   const planets = Object.fromEntries(am.planets.map((p) => [p.name, p]));
   const expected = {
@@ -25,7 +25,7 @@ test('Darbhanga 1982-12-01 03:50 matches AstroSage', async () => {
 
 test('Darbhanga 1982-12-01 15:50 matches AstroSage', async () => {
   const pm = await computePositions('1982-12-01T15:50+05:30', 26.152, 85.897);
-  assert.strictEqual(pm.ascSign, 1);
+  assert.strictEqual(pm.ascSign, 2);
 
   const planets = Object.fromEntries(pm.planets.map((p) => [p.name, p]));
   const expected = {

--- a/tests/chart-orientation.test.js
+++ b/tests/chart-orientation.test.js
@@ -5,7 +5,7 @@ const { computePositions } = require('../src/lib/astro.js');
 test('planet house values match sign mapping and nodes oppose each other', async () => {
   const data = await computePositions('2020-01-01T12:00+00:00', 0, 0);
   data.planets.forEach((p) => {
-    assert.strictEqual(data.signInHouse[p.house], p.sign);
+    assert.strictEqual(data.signInHouse[p.house], p.sign + 1);
   });
   const rahu = data.planets.find((p) => p.name === 'rahu');
   const ketu = data.planets.find((p) => p.name === 'ketu');

--- a/tests/chart-render.test.js
+++ b/tests/chart-render.test.js
@@ -30,8 +30,8 @@ test('North Indian chart uses one outer square and internal grid', () => {
   const svg = new Element('svg');
   global.document = doc;
   const signInHouse = [null];
-  for (let h = 1; h <= 12; h++) signInHouse[h] = h - 1;
-  renderNorthIndian(svg, { ascSign: 0, signInHouse, planets: [] });
+  for (let h = 1; h <= 12; h++) signInHouse[h] = h;
+  renderNorthIndian(svg, { ascSign: 1, signInHouse, planets: [] });
 
   const paths = svg.children.filter((c) => c.tagName === 'path');
   assert.strictEqual(paths.length, 4);

--- a/tests/darbhanga-july-1982.test.js
+++ b/tests/darbhanga-july-1982.test.js
@@ -4,7 +4,7 @@ const { computePositions } = require('../src/lib/astro.js');
 
 test('Darbhanga 1982-07-12 03:50 positions', async () => {
   const res = await computePositions('1982-07-12T03:50+05:30', 26.15216, 85.89707);
-  assert.strictEqual(res.ascSign, 2);
+  assert.strictEqual(res.ascSign, 3);
   const planets = Object.fromEntries(res.planets.map((p) => [p.name, p]));
   assert.strictEqual(planets.moon.house, 9);
 });

--- a/tests/houses-order.test.js
+++ b/tests/houses-order.test.js
@@ -31,8 +31,8 @@ const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
 test('houses and signs increase anti-clockwise from ascendant', () => {
   const signInHouse = [null];
-  for (let h = 1; h <= 12; h++) signInHouse[h] = h - 1;
-  const data = { ascSign: 0, signInHouse, planets: [] };
+  for (let h = 1; h <= 12; h++) signInHouse[h] = h;
+  const data = { ascSign: 1, signInHouse, planets: [] };
 
   global.document = doc;
   const svg = new Element('svg');
@@ -53,7 +53,7 @@ test('houses and signs increase anti-clockwise from ascendant', () => {
   for (let i = 0; i < 12; i++) {
     const current = signInHouse[i + 1];
     const next = signInHouse[(i + 1) % 12 + 1];
-    assert.strictEqual(next, (current + 1) % 12);
+    assert.strictEqual(next, (current % 12) + 1);
 
     const { cx: cx1, cy: cy1 } = HOUSE_CENTROIDS[i];
     const { cx: cx2, cy: cy2 } = HOUSE_CENTROIDS[(i + 1) % 12];

--- a/tests/planet-spacing.test.js
+++ b/tests/planet-spacing.test.js
@@ -28,7 +28,7 @@ const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
 test('planets render in distinct rows below sign label', () => {
   const signInHouse = [null];
-  for (let h = 1; h <= 12; h++) signInHouse[h] = h - 1;
+  for (let h = 1; h <= 12; h++) signInHouse[h] = h;
   const planets = [
     { name: 'p1', house: 2, deg: 0 },
     { name: 'p2', house: 2, deg: 10 },
@@ -38,7 +38,7 @@ test('planets render in distinct rows below sign label', () => {
 
   global.document = doc;
   const svg = new Element('svg');
-  renderNorthIndian(svg, { ascSign: 0, signInHouse, planets });
+  renderNorthIndian(svg, { ascSign: 1, signInHouse, planets });
   delete global.document;
 
   const { cx, cy } = HOUSE_CENTROIDS[1]; // house 2

--- a/tests/reference-case.test.js
+++ b/tests/reference-case.test.js
@@ -28,7 +28,7 @@ const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
 test('reference charts for Darbhanga on 1982-12-01 match expected placements', async () => {
   const am = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
-  assert.strictEqual(am.ascSign, 6);
+  assert.strictEqual(am.ascSign, 7);
   const amPlanets = Object.fromEntries(am.planets.map((p) => [p.name, p]));
   assert.strictEqual(amPlanets.sun.sign, 7);
   assert.strictEqual(amPlanets.sun.house, 2);
@@ -52,7 +52,7 @@ test('reference charts for Darbhanga on 1982-12-01 match expected placements', a
   );
 
   const pm = await computePositions('1982-12-01T15:50+05:30', 26.152, 85.897);
-  assert.strictEqual(pm.ascSign, 1);
+  assert.strictEqual(pm.ascSign, 2);
   const pmPlanets = Object.fromEntries(pm.planets.map((p) => [p.name, p]));
   assert.strictEqual(pmPlanets.sun.sign, 7);
   assert.strictEqual(pmPlanets.sun.house, 7);

--- a/tests/sign-labels.test.js
+++ b/tests/sign-labels.test.js
@@ -28,10 +28,10 @@ const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
 test('renderNorthIndian defaults to numeric sign labels', () => {
   const signInHouse = [null];
-  for (let h = 1; h <= 12; h++) signInHouse[h] = h - 1;
+  for (let h = 1; h <= 12; h++) signInHouse[h] = h;
   global.document = doc;
   const svg = new Element('svg');
-  renderNorthIndian(svg, { ascSign: 0, signInHouse, planets: [] });
+  renderNorthIndian(svg, { ascSign: 1, signInHouse, planets: [] });
   const texts = svg.children.filter(
     (c) => c.tagName === 'text' && c.attributes['font-size'] === '0.05'
   );
@@ -42,10 +42,10 @@ test('renderNorthIndian defaults to numeric sign labels', () => {
 
 test('renderNorthIndian can use abbreviated sign labels', () => {
   const signInHouse = [null];
-  for (let h = 1; h <= 12; h++) signInHouse[h] = h - 1;
+  for (let h = 1; h <= 12; h++) signInHouse[h] = h;
   global.document = doc;
   const svg = new Element('svg');
-  renderNorthIndian(svg, { ascSign: 0, signInHouse, planets: [] }, {
+  renderNorthIndian(svg, { ascSign: 1, signInHouse, planets: [] }, {
     useAbbreviations: true,
   });
   const texts = svg.children.filter(

--- a/tests/text-inside-polygons.test.js
+++ b/tests/text-inside-polygons.test.js
@@ -42,14 +42,14 @@ function pointInPolygon(x, y, poly) {
 
 test('all text elements render inside their house polygons', () => {
   const signInHouse = [null];
-  for (let h = 1; h <= 12; h++) signInHouse[h] = h - 1;
+  for (let h = 1; h <= 12; h++) signInHouse[h] = h;
   const planets = Array.from({ length: 12 }, (_, i) => ({
     name: `p${i}`,
     sign: i,
     house: i + 1,
     deg: 0,
   }));
-  const data = { ascSign: 0, signInHouse, planets };
+  const data = { ascSign: 1, signInHouse, planets };
 
   global.document = doc;
   const svg = new Element('svg');


### PR DESCRIPTION
## Summary
- return house sign mapping as 1–12 in `computePositions`
- render charts with 1-based signs and drop `+1` conversions
- update tests to reflect 1-based sign numbers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b31922126c832b99bd59e00c6fc65f