### PR TITLE
test: verify sign order

### DIFF
--- a/tests/astrosage-compare.test.js
+++ b/tests/astrosage-compare.test.js
@@ -43,3 +43,9 @@ test('Darbhanga 1982-12-01 15:50 matches AstroSage', async () => {
     assert.strictEqual(planets[name].house, house, `${name} house`);
   }
 });
+
+test('Darbhanga 1982-12-01 03:50 sign sequence matches AstroSage', async () => {
+  const am = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
+  const expected = [null, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6];
+  assert.deepStrictEqual(am.signInHouse, expected);
+});


### PR DESCRIPTION
## Summary
- add regression test asserting house-to-sign sequence for reference Darbhanga chart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b31a7537d8832bbef1da5dc39c6b55