### PR TITLE
Use sign-based house calculation

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -85,7 +85,9 @@ export function compute_positions({ datetime, tz, lat, lon }, swe = swisseph) {
     const data = name === 'rahu' ? rahuData : swe.swe_calc_ut(jd, code, flag);
     const { sign, deg } =
       name === 'rahu' ? { sign: rSign, deg: rDeg } : lonToSignDeg(data.longitude);
-    const house = swe.swe_house_pos(jd, lat, lon, 'P', data.longitude, houses);
+    const house = Math.trunc(
+      swe.swe_house_pos(jd, lat, lon, 'P', data.longitude, houses)
+    );
     planets.push({ name, sign, deg, retro: data.longitudeSpeed < 0, house });
   }
   // Ketu opposite Rahu
@@ -94,7 +96,9 @@ export function compute_positions({ datetime, tz, lat, lon }, swe = swisseph) {
   if (((kSign - rSign + 12) % 12) !== 6) {
     throw new Error('Rahu and Ketu must be six signs apart');
   }
-  const ketuHouse = swe.swe_house_pos(jd, lat, lon, 'P', ketuLon, houses);
+  const ketuHouse = Math.trunc(
+    swe.swe_house_pos(jd, lat, lon, 'P', ketuLon, houses)
+  );
   planets.push({
     name: 'ketu',
     sign: kSign,

--- a/swisseph/index.js
+++ b/swisseph/index.js
@@ -282,6 +282,7 @@ export function swe_house_pos(jd, lat, lon, hsys, bodyLon, houses) {
     typeof asc === 'number'
       ? asc
       : swe_houses_ex(jd, lat, lon, hsys, 0).houses[1];
-  const diff = normalizeAngle(bodyLon - ascendant);
-  return Math.floor(diff / 30) + 1; // 1..12
+  const ascSign = Math.floor(ascendant / 30);
+  const bodySign = Math.floor(bodyLon / 30);
+  return ((bodySign - ascSign + 12) % 12) + 1;
 }


### PR DESCRIPTION
## Summary
- determine house position by comparing zodiac signs rather than degree difference
- ensure ephemeris callers treat house position as integer index

## Testing
- `npm test`
- `npm run build` *(fails: sh: 1: vite: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b31faf6cc4832b98f3655f36e79d9e