### PR TITLE
Expose planetary velocity and verify Saturn motion

### DIFF
--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -196,7 +196,16 @@ export async function computePositions(dtISOWithZone, lat, lon) {
     }
     const exalt = exaltedSign[p.name];
     const exalted = exalt !== undefined && sign === exalt;
-    planets.push({ name: p.name, sign, house, deg, retro, combust, exalted });
+    planets.push({
+      name: p.name,
+      sign,
+      house,
+      deg,
+      retro,
+      combust,
+      exalted,
+      speed: p.speed,
+    });
   }
 
   return { ascSign: signInHouse[1], signInHouse, planets };

--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -88,7 +88,14 @@ export function compute_positions({ datetime, tz, lat, lon }, swe = swisseph) {
     const house = Math.trunc(
       swe.swe_house_pos(jd, lat, lon, 'P', data.longitude, houses)
     );
-    planets.push({ name, sign, deg, retro: data.longitudeSpeed < 0, house });
+    planets.push({
+      name,
+      sign,
+      deg,
+      speed: data.longitudeSpeed,
+      retro: data.longitudeSpeed < 0,
+      house,
+    });
   }
   // Ketu opposite Rahu
   const ketuLon = (rahuData.longitude + 180) % 360;
@@ -103,6 +110,7 @@ export function compute_positions({ datetime, tz, lat, lon }, swe = swisseph) {
     name: 'ketu',
     sign: kSign,
     deg: kDeg,
+    speed: -rahuData.longitudeSpeed,
     retro: rahuData.longitudeSpeed < 0,
     house: ketuHouse,
   });

--- a/swisseph/index.js
+++ b/swisseph/index.js
@@ -220,10 +220,13 @@ function siderealLongitude(jd, planetId) {
 
 export function swe_calc_ut(jd, planetId, flags) {
   const lon = siderealLongitude(jd, planetId);
-  const lon2 = siderealLongitude(jd + 1, planetId);
-  let speed = lon2 - lon;
-  if (speed > 180) speed -= 360;
-  if (speed < -180) speed += 360;
+  const delta = 1 / 1440; // one minute step for speed
+  const lonBefore = siderealLongitude(jd - delta, planetId);
+  const lonAfter = siderealLongitude(jd + delta, planetId);
+  let diff = lonAfter - lonBefore;
+  if (diff > 180) diff -= 360;
+  if (diff < -180) diff += 360;
+  const speed = diff / (2 * delta); // degrees per day
   return { longitude: lon, longitudeSpeed: speed };
 }
 

--- a/swisseph/package.json
+++ b/swisseph/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "swisseph",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module"
+}

--- a/tests/saturn-direct.test.js
+++ b/tests/saturn-direct.test.js
@@ -1,0 +1,19 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+async function getCompute() {
+  return (await import('../src/lib/ephemeris.js')).compute_positions;
+}
+
+test('Saturn degree and direct motion on 1982-12-28', async () => {
+  const compute_positions = await getCompute();
+  const result = compute_positions({
+    datetime: '1982-12-28T00:00',
+    tz: 'UTC',
+    lat: 0,
+    lon: 0,
+  });
+  const saturn = result.planets.find((p) => p.name === 'saturn');
+  assert.ok(Math.abs(saturn.deg - 29.63) < 0.1);
+  assert.ok(saturn.speed > 0, 'Saturn should be direct');
+});


### PR DESCRIPTION
## Summary
- refine `swe_calc_ut` to estimate instantaneous speed from one-minute samples
- surface longitude speed through `compute_positions` and `computePositions`
- add regression test ensuring Saturn is direct at ~29.63° Virgo on 1982-12-28

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3204b5f64832b95a8e397f73d3304