### PR TITLE
Use tolerance when flagging retrograde motion

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -93,7 +93,9 @@ export function compute_positions({ datetime, tz, lat, lon }, swe = swisseph) {
       sign,
       deg,
       speed: data.longitudeSpeed,
-      retro: data.longitudeSpeed < 0,
+      // Treat very small negative speeds as direct motion to avoid
+      // floating point noise from triggering retrograde flags.
+      retro: data.longitudeSpeed <= -1e-5,
       house,
     });
   }
@@ -111,7 +113,8 @@ export function compute_positions({ datetime, tz, lat, lon }, swe = swisseph) {
     sign: kSign,
     deg: kDeg,
     speed: -rahuData.longitudeSpeed,
-    retro: rahuData.longitudeSpeed < 0,
+    // Ketu shares motion with Rahu; apply the same tolerance check.
+    retro: rahuData.longitudeSpeed <= -1e-5,
     house: ketuHouse,
   });
 

--- a/tests/ephemeris.test.js
+++ b/tests/ephemeris.test.js
@@ -44,7 +44,8 @@ test('house cusps and retrograde flags', async () => {
       const data = {
         0: { longitude: 100, longitudeSpeed: 1 }, // Sun in Cancer
         1: { longitude: 210, longitudeSpeed: -0.5 }, // Moon retro in Libra
-        2: { longitude: 50, longitudeSpeed: 0.1 },
+        // Mercury has a tiny negative speed that should not count as retrograde
+        2: { longitude: 50, longitudeSpeed: -1e-6 },
         3: { longitude: 10, longitudeSpeed: 0.1 },
         4: { longitude: 80, longitudeSpeed: 0.1 },
         5: { longitude: 170, longitudeSpeed: 0.1 },
@@ -71,6 +72,7 @@ test('house cusps and retrograde flags', async () => {
   assert.strictEqual(planets.moon.sign, 8);
   assert.strictEqual(planets.moon.house, 3);
   assert.strictEqual(planets.moon.retro, true);
+  assert.strictEqual(planets.mercury.retro, false);
 
   assert.strictEqual(planets.rahu.retro, true);
   assert.strictEqual(planets.rahu.house, 9);


### PR DESCRIPTION
## Summary
- apply a tolerance check for retrograde detection so tiny negative speeds don't trigger retrograde flags
- extend ephemeris tests to ensure small negative speeds are treated as direct motion

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b325af6ed4832b831069c8a1a638ec