### PR TITLE
Normalize house positions from Swiss Ephemeris

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -85,9 +85,8 @@ export function compute_positions({ datetime, tz, lat, lon }, swe = swisseph) {
     const data = name === 'rahu' ? rahuData : swe.swe_calc_ut(jd, code, flag);
     const { sign, deg } =
       name === 'rahu' ? { sign: rSign, deg: rDeg } : lonToSignDeg(data.longitude);
-    const house = Math.trunc(
-      swe.swe_house_pos(jd, lat, lon, 'P', data.longitude, houses)
-    );
+    let house = swe.swe_house_pos(jd, lat, lon, 'P', data.longitude, houses);
+    house = ((Math.floor(house) - 1 + 12) % 12) + 1; // 1..12
     planets.push({
       name,
       sign,
@@ -105,9 +104,8 @@ export function compute_positions({ datetime, tz, lat, lon }, swe = swisseph) {
   if (((kSign - rSign + 12) % 12) !== 6) {
     throw new Error('Rahu and Ketu must be six signs apart');
   }
-  const ketuHouse = Math.trunc(
-    swe.swe_house_pos(jd, lat, lon, 'P', ketuLon, houses)
-  );
+  let ketuHouse = swe.swe_house_pos(jd, lat, lon, 'P', ketuLon, houses);
+  ketuHouse = ((Math.floor(ketuHouse) - 1 + 12) % 12) + 1; // 1..12
   planets.push({
     name: 'ketu',
     sign: kSign,


### PR DESCRIPTION
## Summary
- Normalize `swe_house_pos` results to range 1..12 for planets and Ketu
- Confirm Mercury, Venus, and Mars house placements for 27-Oct-1982 03:50 Darbhanga chart

## Testing
- `npm test`
- `node - <<'NODE'
import { compute_positions } from './src/lib/ephemeris.js';
const res = compute_positions({datetime:'1982-10-27T03:50:00', tz:'Asia/Kolkata', lat:26.154, lon:85.892});
console.log(JSON.stringify(res.planets.filter(p=>['mercury','venus','mars'].includes(p.name)), null, 2));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68b3275c1174832b9cb543f23c756971