### PR TITLE
Position sign labels away from planet details

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -111,7 +111,7 @@ export default function Chart({
                 padding: (2 / 300) * size,
               }}
             >
-              <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+              <div className="absolute top-1 right-1 pointer-events-none">
                 <span className="text-amber-700 font-bold text-[clamp(0.9rem,1.5vw,1.2rem)] leading-none">
                   {getSignLabel(signNum - 1, { useAbbreviations })}
                 </span>


### PR DESCRIPTION
## Summary
- move sign labels to top-right corner in each house to avoid overlapping planet list

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3281ca524832bbb9256e7ad0979c9