### PR TITLE
Use ascendant sign from base calculation

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -92,7 +92,7 @@ export default function Chart({
           const bx = (minX + maxX) / 2;
           const by = (minY + maxY) / 2;
           const houseNum = idx + 1;
-          const signNum = signInHouse[houseNum];
+          const signNum = houseNum === 1 ? data.ascSign : signInHouse[houseNum];
 
           const margin = (4 / 300) * size; // scale margin with chart size
           const width = (maxX - minX) * size - margin;
@@ -144,6 +144,7 @@ export default function Chart({
 
 Chart.propTypes = {
   data: PropTypes.shape({
+    ascSign: PropTypes.number.isRequired,
     signInHouse: PropTypes.arrayOf(PropTypes.number).isRequired,
     planets: PropTypes.arrayOf(
       PropTypes.shape({

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -208,7 +208,7 @@ export async function computePositions(dtISOWithZone, lat, lon) {
     });
   }
 
-  return { ascSign: signInHouse[1], signInHouse, planets };
+  return { ascSign: base.ascSign, signInHouse, planets };
 }
 
 export function renderNorthIndian(svgEl, data, options = {}) {


### PR DESCRIPTION
## Summary
- Return ascendant sign from base ephemeris data
- Use `data.ascSign` in Chart component and validate via PropTypes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b32bbcf120832bac78b55836513a16