### PR TITLE
Reuse lonToSignDeg for house sign mapping

### DIFF
--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon';
-import { compute_positions } from './ephemeris.js';
+import { compute_positions, lonToSignDeg } from './ephemeris.js';
 
 const svgNS = 'http://www.w3.org/2000/svg';
 
@@ -144,13 +144,11 @@ export async function computePositions(dtISOWithZone, lat, lon) {
   });
 
   // Derive sign numbers (1–12) for each house from the returned cusp
-  // longitudes. Swiss Ephemeris gives cusp longitudes in degrees; we map
-  // these to signs and store them as 1-based values.
+  // longitudes. Swiss Ephemeris gives cusp longitudes in degrees; use
+  // lonToSignDeg to convert these to 1-based sign numbers.
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) {
-    const lon = base.houses[h];
-    const sign = Math.floor((((lon % 360) + 360) % 360) / 30) + 1;
-    signInHouse[h] = sign;
+    signInHouse[h] = lonToSignDeg(base.houses[h]).sign;
   }
   if (process.env.DEBUG_HOUSES) {
     console.log('signInHouse:', signInHouse);

--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -15,7 +15,7 @@ if (swisseph.swe_set_sid_mode) {
   } catch {}
 }
 
-function lonToSignDeg(longitude) {
+export function lonToSignDeg(longitude) {
   const norm = ((longitude % 360) + 360) % 360;
   const sign = Math.floor(norm / 30) + 1; // 1..12
   const deg = +(norm % 30).toFixed(2);

--- a/tests/sign-in-house-sequence.test.js
+++ b/tests/sign-in-house-sequence.test.js
@@ -1,0 +1,9 @@
+const assert = require('node:assert');
+const test = require('node:test');
+const { computePositions } = require('../src/lib/astro.js');
+
+test('Darbhanga 1982-12-01 03:50 signInHouse sequence', async () => {
+  const result = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
+  const expected = [null, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6];
+  assert.deepStrictEqual(result.signInHouse, expected);
+});


### PR DESCRIPTION
## Summary
- export `lonToSignDeg` from the ephemeris utility
- build `signInHouse` using `lonToSignDeg` for each cusp longitude
- add test verifying the 12-sign sequence for a sample chart

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b32fa0d634832b8783e3a4dc916ecf