### PR TITLE
Use swe flags for retrograde detection

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -91,14 +91,13 @@ export function compute_positions({ datetime, tz, lat, lon }, swe = swisseph) {
     const { sign, deg } =
       name === 'rahu' ? { sign: rSign, deg: rDeg } : lonToSignDeg(data.longitude);
     const house = houseOf(data.longitude);
+    const flags = data.flags || 0;
     planets.push({
       name,
       sign,
       deg,
       speed: data.longitudeSpeed,
-      // Treat very small negative speeds as direct motion to avoid
-      // floating point noise from triggering retrograde flags.
-      retro: data.longitudeSpeed <= -1e-5,
+      retro: (flags & swe.SEFLG_RETROGRADE) !== 0,
       house,
     });
   }
@@ -114,8 +113,7 @@ export function compute_positions({ datetime, tz, lat, lon }, swe = swisseph) {
     sign: kSign,
     deg: kDeg,
     speed: -rahuData.longitudeSpeed,
-    // Ketu shares motion with Rahu; apply the same tolerance check.
-    retro: rahuData.longitudeSpeed <= -1e-5,
+    retro: (rahuData.flags & swe.SEFLG_RETROGRADE) !== 0,
     house: ketuHouse,
   });
 

--- a/swisseph/index.js
+++ b/swisseph/index.js
@@ -15,6 +15,7 @@ export const SE_MEAN_NODE = 8; // Ketu approximated
 export const SEFLG_SPEED = 1 << 0;
 export const SEFLG_SWIEPH = 1 << 1;
 export const SEFLG_SIDEREAL = 1 << 2;
+export const SEFLG_RETROGRADE = 1 << 3;
 
 export const SE_SIDM_LAHIRI = 0; // id for Lahiri mode
 export const SE_GREG_CAL = 1;
@@ -239,7 +240,8 @@ export function swe_calc_ut(jd, planetId, flags) {
   if (diff > 180) diff -= 360;
   if (diff < -180) diff += 360;
   const speed = diff / (2 * delta); // degrees per day
-  return { longitude: lon, longitudeSpeed: speed };
+  const ret = speed <= -1e-5 ? SEFLG_RETROGRADE : 0;
+  return { longitude: lon, longitudeSpeed: speed, flags: ret };
 }
 
 function localSiderealTime(jd, lon) {

--- a/tests/ephemeris.test.js
+++ b/tests/ephemeris.test.js
@@ -13,6 +13,7 @@ test('house cusps and retrograde flags', async () => {
     SEFLG_SIDEREAL: 2,
     SEFLG_SWIEPH: 4,
     SEFLG_SPEED: 8,
+    SEFLG_RETROGRADE: 16,
     SE_SUN: 0,
     SE_MOON: 1,
     SE_MERCURY: 2,
@@ -42,15 +43,23 @@ test('house cusps and retrograde flags', async () => {
     }), // Leo 3° ascendant
     swe_calc_ut: (jd, id, flag) => {
       const data = {
-        0: { longitude: 100, longitudeSpeed: 1 }, // Sun in Cancer
-        1: { longitude: 210, longitudeSpeed: -0.5 }, // Moon retro in Libra
+        0: { longitude: 100, longitudeSpeed: 1, flags: 0 }, // Sun in Cancer
+        1: {
+          longitude: 210,
+          longitudeSpeed: -0.5,
+          flags: fakeSwe.SEFLG_RETROGRADE,
+        }, // Moon retro in Libra
         // Mercury has a tiny negative speed that should not count as retrograde
-        2: { longitude: 50, longitudeSpeed: -1e-6 },
-        3: { longitude: 10, longitudeSpeed: 0.1 },
-        4: { longitude: 80, longitudeSpeed: 0.1 },
-        5: { longitude: 170, longitudeSpeed: 0.1 },
-        6: { longitude: 300, longitudeSpeed: 0.1 },
-        7: { longitude: 30, longitudeSpeed: -0.1 }, // Rahu retro in Taurus
+        2: { longitude: 50, longitudeSpeed: -1e-6, flags: 0 },
+        3: { longitude: 10, longitudeSpeed: 0.1, flags: 0 },
+        4: { longitude: 80, longitudeSpeed: 0.1, flags: 0 },
+        5: { longitude: 170, longitudeSpeed: 0.1, flags: 0 },
+        6: { longitude: 300, longitudeSpeed: 0.1, flags: 0 },
+        7: {
+          longitude: 30,
+          longitudeSpeed: -0.1,
+          flags: fakeSwe.SEFLG_RETROGRADE,
+        }, // Rahu retro in Taurus
       };
       return data[id];
     },

--- a/tests/saturn-direct.test.js
+++ b/tests/saturn-direct.test.js
@@ -13,7 +13,12 @@ test('Saturn degree and direct motion on 1982-12-28', async () => {
     lat: 0,
     lon: 0,
   });
-  const saturn = result.planets.find((p) => p.name === 'saturn');
+  const planets = Object.fromEntries(result.planets.map((p) => [p.name, p]));
+  const saturn = planets.saturn;
   assert.ok(Math.abs(saturn.deg - 29.63) < 0.1);
-  assert.ok(saturn.speed > 0, 'Saturn should be direct');
+  const direct = ['sun', 'moon', 'mercury', 'venus', 'mars', 'saturn'];
+  for (const name of direct) {
+    assert.ok(!planets[name].retro, `${name} should be direct`);
+  }
+  assert.ok(planets.jupiter.retro, 'jupiter should be retrograde');
 });


### PR DESCRIPTION
## Summary
- derive planet retrograde status from `swe_calc_ut` flag bits
- expose a `SEFLG_RETROGRADE` flag in the Swiss Ephemeris shim
- expand tests to cover direct and retrograde motions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3348b0d20832ba2ab850a47c5ad80