### PR TITLE
feat: propagate retrograde flag

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -63,7 +63,8 @@ export default function Chart({
       degree = `${d}°${String(m).padStart(2, '0')}'`;
     }
     let abbr = PLANET_ABBR[p.name.toLowerCase()] || p.name.slice(0, 2);
-    if (p.retro) abbr += '(R)';
+    const isRetro = Boolean(p.retro);
+    if (isRetro) abbr += '(R)';
     if (p.combust) abbr += '(C)';
     if (p.exalted) abbr += '(Ex)';
     const deg = degree;

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -188,7 +188,7 @@ export async function computePositions(dtISOWithZone, lat, lon) {
     const house = p.house;
     const deg = p.deg;
     const lon = sign * 30 + deg;
-    const retro = p.retro;
+    const retro = Boolean(p.retro);
     const cDeg = combustDeg[p.name];
     let combust = false;
     if (cDeg !== undefined) {

--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -80,6 +80,7 @@ export function compute_positions({ datetime, tz, lat, lon }, swe = swisseph) {
 
   const planets = [];
   const rahuData = swe.swe_calc_ut(jd, swe.SE_TRUE_NODE, flag);
+  const rahuFlags = rahuData.flags || 0;
   const { sign: rSign, deg: rDeg } = lonToSignDeg(rahuData.longitude);
   const houseOf = (bodyLon) => {
     let house = swe.swe_house_pos(jd, lat, lon, 'P', bodyLon, houses);
@@ -91,7 +92,7 @@ export function compute_positions({ datetime, tz, lat, lon }, swe = swisseph) {
     const data = name === 'rahu' ? rahuData : swe.swe_calc_ut(jd, code, flag);
     const { sign, deg } =
       name === 'rahu' ? { sign: rSign, deg: rDeg } : lonToSignDeg(data.longitude);
-    const flags = data.flags || 0;
+    const flags = name === 'rahu' ? rahuFlags : data.flags || 0;
     planets.push({
       name,
       sign,
@@ -112,7 +113,7 @@ export function compute_positions({ datetime, tz, lat, lon }, swe = swisseph) {
     sign: kSign,
     deg: kDeg,
     speed: -rahuData.longitudeSpeed,
-    retro: (rahuData.flags & swe.SEFLG_RETROGRADE) !== 0,
+    retro: (rahuFlags & swe.SEFLG_RETROGRADE) !== 0,
     house: houseOf(ketuLon),
   });
 

--- a/tests/saturn-direct.test.js
+++ b/tests/saturn-direct.test.js
@@ -1,18 +1,9 @@
 import assert from 'node:assert';
 import test from 'node:test';
-
-async function getCompute() {
-  return (await import('../src/lib/ephemeris.js')).compute_positions;
-}
+import { computePositions } from '../src/lib/astro.js';
 
 test('Saturn degree and direct motion on 1982-12-28', async () => {
-  const compute_positions = await getCompute();
-  const result = compute_positions({
-    datetime: '1982-12-28T00:00',
-    tz: 'UTC',
-    lat: 0,
-    lon: 0,
-  });
+  const result = await computePositions('1982-12-28T00:00+00:00', 0, 0);
   const planets = Object.fromEntries(result.planets.map((p) => [p.name, p]));
   const saturn = planets.saturn;
   assert.ok(Math.abs(saturn.deg - 29.63) < 0.1);


### PR DESCRIPTION
## Summary
- read retrograde flag bits from `swe_calc_ut` and surface them on planet data
- pass retrograde boolean through high-level compute and chart display layers
- ensure key planets are marked direct in regression test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3ca7963d4832bb2cb22a3a5ee9329