### PR TITLE
Add chart regression rendering snapshot

### DIFF
--- a/tests/chart-regression.test.js
+++ b/tests/chart-regression.test.js
@@ -1,6 +1,31 @@
 const assert = require('node:assert');
 const test = require('node:test');
 const calculateChart = require('../src/calculateChart.js').default;
+const { renderNorthIndian } = require('../src/lib/astro.js');
+
+class Element {
+  constructor(tag) {
+    this.tagName = tag;
+    this.attributes = {};
+    this.children = [];
+    this.textContent = '';
+  }
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+  }
+  appendChild(child) {
+    this.children.push(child);
+  }
+  removeChild(child) {
+    const i = this.children.indexOf(child);
+    if (i >= 0) this.children.splice(i, 1);
+  }
+  get firstChild() {
+    return this.children[0];
+  }
+}
+
+const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
 test('calculateChart matches AstroSage for Darbhanga 1982-12-01 03:50', async () => {
   const result = await calculateChart({
@@ -65,4 +90,43 @@ test('calculateChart matches AstroSage for Darbhanga 1982-12-01 03:50', async ()
   for (const [name, combust] of Object.entries(expectedCombust)) {
     assert.strictEqual(planets[name].combust, combust, `${name} combust`);
   }
+
+  // Render chart and compare snapshot to guard against layout regressions
+  global.document = doc;
+  const svg = new Element('svg');
+  renderNorthIndian(svg, result);
+  delete global.document;
+  const snapshot = svg.children.map((c) => ({
+    tag: c.tagName,
+    attrs: c.attributes,
+    text: c.textContent,
+  }));
+  assert.deepStrictEqual(snapshot, [
+    { tag: 'path', attrs: { d: 'M0 0 L1 0 L1 1 L0 1 Z', 'stroke-width': '0.02' }, text: '' },
+    { tag: 'path', attrs: { d: 'M0 0 L1 1', 'stroke-width': '0.01' }, text: '' },
+    { tag: 'path', attrs: { d: 'M1 0 L0 1', 'stroke-width': '0.01' }, text: '' },
+    { tag: 'path', attrs: { d: 'M0.5 0 L1 0.5 L0.5 1 L0 0.5 Z', 'stroke-width': '0.01' }, text: '' },
+    { tag: 'text', attrs: { x: '0.27', y: '0.05', 'text-anchor': 'start', 'font-size': '0.03' }, text: 'Asc' },
+    { tag: 'text', attrs: { x: '0.73', y: '0.05', 'text-anchor': 'end', 'font-size': '0.05' }, text: '9' },
+    { tag: 'text', attrs: { x: '0.48', y: '0.05', 'text-anchor': 'end', 'font-size': '0.05' }, text: '10' },
+    { tag: 'text', attrs: { x: '0.23', y: '0.05', 'text-anchor': 'end', 'font-size': '0.05' }, text: '11' },
+    { tag: 'text', attrs: { x: '0.48', y: '0.3', 'text-anchor': 'end', 'font-size': '0.05' }, text: '12' },
+    { tag: 'text', attrs: { x: '0.23', y: '0.55', 'text-anchor': 'end', 'font-size': '0.05' }, text: '1' },
+    { tag: 'text', attrs: { x: '0.48', y: '0.8', 'text-anchor': 'end', 'font-size': '0.05' }, text: '2' },
+    { tag: 'text', attrs: { x: '0.73', y: '0.55', 'text-anchor': 'end', 'font-size': '0.05' }, text: '3' },
+    { tag: 'text', attrs: { x: '0.98', y: '0.8', 'text-anchor': 'end', 'font-size': '0.05' }, text: '4' },
+    { tag: 'text', attrs: { x: '0.98', y: '0.55', 'text-anchor': 'end', 'font-size': '0.05' }, text: '5' },
+    { tag: 'text', attrs: { x: '0.98', y: '0.3', 'text-anchor': 'end', 'font-size': '0.05' }, text: '6' },
+    { tag: 'text', attrs: { x: '0.98', y: '0.05', 'text-anchor': 'end', 'font-size': '0.05' }, text: '7' },
+    { tag: 'text', attrs: { x: '0.98', y: '0.05', 'text-anchor': 'end', 'font-size': '0.05' }, text: '8' },
+    { tag: 'text', attrs: { x: '0.5', y: '0.32', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "saturn(R)(Ex) 00°14'" },
+    { tag: 'text', attrs: { x: '0.25', y: '0.15333333333333332', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "sun 14°46'" },
+    { tag: 'text', attrs: { x: '0.25', y: '0.19333333333333333', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "jupiter(R)(C) 05°04'" },
+    { tag: 'text', attrs: { x: '0.08333333333333333', y: '0.32', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "ketu(R) 11°53'" },
+    { tag: 'text', attrs: { x: '0.25', y: '0.98', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "mars 08°07'" },
+    { tag: 'text', attrs: { x: '0.5', y: '0.8200000000000001', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "mercury(R) 29°13'" },
+    { tag: 'text', attrs: { x: '0.5', y: '0.8600000000000001', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "venus 10°02'" },
+    { tag: 'text', attrs: { x: '0.75', y: '0.98', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "moon(Ex) 13°17'" },
+    { tag: 'text', attrs: { x: '0.9166666666666666', y: '0.8200000000000001', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "rahu(R) 11°53'" },
+  ]);
 });


### PR DESCRIPTION
## Summary
- exercise `calculateChart` with sample birth data and verify AstroSage alignment
- snapshot SVG rendering to guard against chart layout regressions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3d2f58270832b9617e254eb4c3e9b