### PR TITLE
Align house sign mapping with Swiss Ephemeris

### DIFF
--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -155,15 +155,12 @@ export async function computePositions(dtISOWithZone, lat, lon) {
     lon,
   });
 
-  // Derive sign numbers (1–12) for each house from the returned cusp
-  // longitudes. Swiss Ephemeris gives cusp longitudes in degrees with the
-  // array starting at the ascendant (index 1). For the North Indian chart
-  // layout the sign sequence effectively begins two houses later, so rotate
-  // the cusps by two positions before converting them to sign numbers.
+  // Derive sign numbers (1–12) for each house directly from the cusp
+  // longitudes returned by Swiss Ephemeris. The `houses` array is 1-indexed
+  // with index 1 representing the ascendant.
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) {
-    const idx = ((h + 1) % 12) + 1; // 3..12,1,2
-    signInHouse[h] = lonToSignDeg(base.houses[idx]).sign;
+    signInHouse[h] = lonToSignDeg(base.houses[h]).sign;
   }
   if (process.env.DEBUG_HOUSES) {
     console.log('signInHouse:', signInHouse);

--- a/tests/ascendant-regression.test.js
+++ b/tests/ascendant-regression.test.js
@@ -12,7 +12,7 @@ test('Darbhanga 1982-10-27 03:50 ascendant regression', async () => {
   });
 
   assert.strictEqual(result.ascSign, 6);
-  assert.deepStrictEqual(result.signInHouse, [null, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6, 7]);
+  assert.deepStrictEqual(result.signInHouse, [null, 6, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5]);
 
   const planets = Object.fromEntries(result.planets.map((p) => [p.name, p]));
   assert.strictEqual(planets.sun.house, 2);

--- a/tests/astrosage-compare.test.js
+++ b/tests/astrosage-compare.test.js
@@ -46,6 +46,6 @@ test('Darbhanga 1982-12-01 15:50 matches AstroSage', async () => {
 
 test('Darbhanga 1982-12-01 03:50 sign sequence matches AstroSage', async () => {
   const am = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
-  const expected = [null, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8];
+  const expected = [null, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6];
   assert.deepStrictEqual(am.signInHouse, expected);
 });

--- a/tests/chart-orientation.test.js
+++ b/tests/chart-orientation.test.js
@@ -5,10 +5,7 @@ const { computePositions } = require('../src/lib/astro.js');
 test('planet house values match sign mapping and nodes oppose each other', async () => {
   const data = await computePositions('2020-01-01T12:00+00:00', 0, 0);
   data.planets.forEach((p) => {
-    assert.strictEqual(
-      data.signInHouse[p.house],
-      ((p.sign + 2) % 12) + 1
-    );
+    assert.strictEqual(data.signInHouse[p.house], p.sign + 1);
   });
   const rahu = data.planets.find((p) => p.name === 'rahu');
   const ketu = data.planets.find((p) => p.name === 'ketu');

--- a/tests/chart-regression.test.js
+++ b/tests/chart-regression.test.js
@@ -40,7 +40,7 @@ test('calculateChart matches AstroSage for Darbhanga 1982-12-01 03:50', async ()
   assert.strictEqual(result.ascSign, 7);
 
   // Sign sequence (sign in each house)
-  assert.deepStrictEqual(result.signInHouse, [null, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8]);
+  assert.deepStrictEqual(result.signInHouse, [null, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6]);
 
   // Expected house placement for each planet
   const planets = Object.fromEntries(result.planets.map((p) => [p.name, p]));
@@ -107,18 +107,18 @@ test('calculateChart matches AstroSage for Darbhanga 1982-12-01 03:50', async ()
     { tag: 'path', attrs: { d: 'M1 0 L0 1', 'stroke-width': '0.01' }, text: '' },
     { tag: 'path', attrs: { d: 'M0.5 0 L1 0.5 L0.5 1 L0 0.5 Z', 'stroke-width': '0.01' }, text: '' },
     { tag: 'text', attrs: { x: '0.27', y: '0.05', 'text-anchor': 'start', 'font-size': '0.03' }, text: 'Asc' },
-    { tag: 'text', attrs: { x: '0.73', y: '0.05', 'text-anchor': 'end', 'font-size': '0.05' }, text: '9' },
-    { tag: 'text', attrs: { x: '0.48', y: '0.05', 'text-anchor': 'end', 'font-size': '0.05' }, text: '10' },
-    { tag: 'text', attrs: { x: '0.23', y: '0.05', 'text-anchor': 'end', 'font-size': '0.05' }, text: '11' },
-    { tag: 'text', attrs: { x: '0.48', y: '0.3', 'text-anchor': 'end', 'font-size': '0.05' }, text: '12' },
-    { tag: 'text', attrs: { x: '0.23', y: '0.55', 'text-anchor': 'end', 'font-size': '0.05' }, text: '1' },
-    { tag: 'text', attrs: { x: '0.48', y: '0.8', 'text-anchor': 'end', 'font-size': '0.05' }, text: '2' },
-    { tag: 'text', attrs: { x: '0.73', y: '0.55', 'text-anchor': 'end', 'font-size': '0.05' }, text: '3' },
-    { tag: 'text', attrs: { x: '0.98', y: '0.8', 'text-anchor': 'end', 'font-size': '0.05' }, text: '4' },
-    { tag: 'text', attrs: { x: '0.98', y: '0.55', 'text-anchor': 'end', 'font-size': '0.05' }, text: '5' },
-    { tag: 'text', attrs: { x: '0.98', y: '0.3', 'text-anchor': 'end', 'font-size': '0.05' }, text: '6' },
-    { tag: 'text', attrs: { x: '0.98', y: '0.05', 'text-anchor': 'end', 'font-size': '0.05' }, text: '7' },
-    { tag: 'text', attrs: { x: '0.98', y: '0.05', 'text-anchor': 'end', 'font-size': '0.05' }, text: '8' },
+    { tag: 'text', attrs: { x: '0.73', y: '0.05', 'text-anchor': 'end', 'font-size': '0.05' }, text: '7' },
+    { tag: 'text', attrs: { x: '0.48', y: '0.05', 'text-anchor': 'end', 'font-size': '0.05' }, text: '8' },
+    { tag: 'text', attrs: { x: '0.23', y: '0.05', 'text-anchor': 'end', 'font-size': '0.05' }, text: '9' },
+    { tag: 'text', attrs: { x: '0.48', y: '0.3', 'text-anchor': 'end', 'font-size': '0.05' }, text: '10' },
+    { tag: 'text', attrs: { x: '0.23', y: '0.55', 'text-anchor': 'end', 'font-size': '0.05' }, text: '11' },
+    { tag: 'text', attrs: { x: '0.48', y: '0.8', 'text-anchor': 'end', 'font-size': '0.05' }, text: '12' },
+    { tag: 'text', attrs: { x: '0.73', y: '0.55', 'text-anchor': 'end', 'font-size': '0.05' }, text: '1' },
+    { tag: 'text', attrs: { x: '0.98', y: '0.8', 'text-anchor': 'end', 'font-size': '0.05' }, text: '2' },
+    { tag: 'text', attrs: { x: '0.98', y: '0.55', 'text-anchor': 'end', 'font-size': '0.05' }, text: '3' },
+    { tag: 'text', attrs: { x: '0.98', y: '0.3', 'text-anchor': 'end', 'font-size': '0.05' }, text: '4' },
+    { tag: 'text', attrs: { x: '0.98', y: '0.05', 'text-anchor': 'end', 'font-size': '0.05' }, text: '5' },
+    { tag: 'text', attrs: { x: '0.98', y: '0.05', 'text-anchor': 'end', 'font-size': '0.05' }, text: '6' },
     { tag: 'text', attrs: { x: '0.5', y: '0.32', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "saturn(R)(Ex) 00°14'" },
     { tag: 'text', attrs: { x: '0.25', y: '0.15333333333333332', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "sun 14°46'" },
     { tag: 'text', attrs: { x: '0.25', y: '0.19333333333333333', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "jupiter(R)(C) 05°04'" },

--- a/tests/sign-in-house-sequence.test.js
+++ b/tests/sign-in-house-sequence.test.js
@@ -5,6 +5,6 @@ const { computePositions } = require('../src/lib/astro.js');
 test('Darbhanga 1982-12-01 03:50 ascendant and sign sequence', async () => {
   const result = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
   assert.strictEqual(result.ascSign, 7);
-  const expected = [null, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8];
+  const expected = [null, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6];
   assert.deepStrictEqual(result.signInHouse, expected);
 });


### PR DESCRIPTION
## Summary
- derive house sign sequence directly from Swiss Ephemeris cusps without rotation
- keep ascendant sign independent of house sign sequence
- update tests and chart snapshot to reflect new sign ordering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3e65e1adc832bb52146d2f97af199