### PR TITLE
feat: overlay sign labels with padding

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -86,6 +86,7 @@ export default function Chart({
           const width = (maxX - minX) * size - margin;
           const height = (maxY - minY) * size - margin;
 
+          const labelPad = (4 / 300) * size;
           return (
             <div
               key={houseNum}
@@ -99,19 +100,24 @@ export default function Chart({
                 padding: (2 / 300) * size,
               }}
             >
-              <div className="absolute top-1 right-1 z-0 pointer-events-none">
-                <span className="text-amber-700 font-bold text-[clamp(0.9rem,1.5vw,1.2rem)] leading-none">
-                  {getSignLabel(signNum - 1, { useAbbreviations })}
-                </span>
-              </div>
-
-              {houseNum === 1 && (
-                <div className="absolute top-1 left-1 z-0 pointer-events-none">
-                  <span className="text-amber-700 text-[0.7rem] font-semibold leading-none">
-                    Asc
+              <div
+                className="absolute inset-0 pointer-events-none z-0"
+                style={{ padding: labelPad }}
+              >
+                <div className="absolute top-0 right-0">
+                  <span className="text-amber-700 font-bold text-[clamp(0.9rem,1.5vw,1.2rem)] leading-none">
+                    {getSignLabel(signNum - 1, { useAbbreviations })}
                   </span>
                 </div>
-              )}
+
+                {houseNum === 1 && (
+                  <div className="absolute top-0 left-0">
+                    <span className="text-amber-700 text-[0.7rem] font-semibold leading-none">
+                      Asc
+                    </span>
+                  </div>
+                )}
+              </div>
 
               <div className="flex flex-col items-center justify-center h-full gap-1 text-amber-900 font-medium text-[clamp(0.55rem,0.75vw,0.85rem)] z-10">
                 {planetByHouse[houseNum] &&

--- a/tests/sign-label-padding.test.js
+++ b/tests/sign-label-padding.test.js
@@ -1,0 +1,87 @@
+const assert = require('node:assert');
+const test = require('node:test');
+const { renderNorthIndian, HOUSE_BBOXES } = require('../src/lib/astro.js');
+
+class Element {
+  constructor(tag) {
+    this.tagName = tag;
+    this.attributes = {};
+    this.children = [];
+    this.textContent = '';
+  }
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+  }
+  appendChild(child) {
+    this.children.push(child);
+  }
+  removeChild(child) {
+    const i = this.children.indexOf(child);
+    if (i >= 0) this.children.splice(i, 1);
+  }
+  get firstChild() {
+    return this.children[0];
+  }
+}
+
+const doc = { createElementNS: (ns, tag) => new Element(tag) };
+
+test('sign labels keep padding from borders and planets', () => {
+  const signInHouse = [null];
+  for (let h = 1; h <= 12; h++) signInHouse[h] = h;
+  const planets = [];
+  for (let h = 1; h <= 12; h++) {
+    planets.push({ name: `p${h}`, house: h, deg: 0 });
+  }
+
+  global.document = doc;
+  const svg = new Element('svg');
+  renderNorthIndian(svg, { ascSign: 1, signInHouse, planets });
+  delete global.document;
+
+  const texts = svg.children.filter((c) => c.tagName === 'text');
+  const snapshot = [];
+
+  for (let h = 1; h <= 12; h++) {
+    const bbox = HOUSE_BBOXES[h - 1];
+    const signX = bbox.maxX - 0.02;
+    const signY = bbox.minY + 0.05;
+
+    const signNode = texts.find(
+      (t) =>
+        Math.abs(Number(t.attributes.x) - signX) < 1e-9 &&
+        Math.abs(Number(t.attributes.y) - signY) < 1e-9
+    );
+    assert.ok(signNode, `missing sign label for house ${h}`);
+
+    const planetNodes = texts.filter((t) =>
+      t.textContent.startsWith(`p${h} `)
+    );
+    const planetYs = planetNodes.map((t) => Number(t.attributes.y));
+    const minPlanetY = planetYs.length ? Math.min(...planetYs) : null;
+    const gap = minPlanetY !== null ? +(minPlanetY - signY).toFixed(2) : null;
+
+    const xPad = +(bbox.maxX - signX).toFixed(2);
+    const yPad = +(signY - bbox.minY).toFixed(2);
+    snapshot.push({ house: h, xPad, yPad, planetGap: gap });
+
+    assert.ok(xPad >= 0.02, 'label touches right border');
+    assert.ok(yPad >= 0.05, 'label touches top border');
+    if (gap !== null) assert.ok(gap >= 0.02, 'label overlaps planet');
+  }
+
+  assert.deepStrictEqual(snapshot, [
+    { house: 1, xPad: 0.02, yPad: 0.05, planetGap: 0.27 },
+    { house: 2, xPad: 0.02, yPad: 0.05, planetGap: 0.1 },
+    { house: 3, xPad: 0.02, yPad: 0.05, planetGap: 0.27 },
+    { house: 4, xPad: 0.02, yPad: 0.05, planetGap: 0.27 },
+    { house: 5, xPad: 0.02, yPad: 0.05, planetGap: 0.27 },
+    { house: 6, xPad: 0.02, yPad: 0.05, planetGap: 0.18 },
+    { house: 7, xPad: 0.02, yPad: 0.05, planetGap: 0.27 },
+    { house: 8, xPad: 0.02, yPad: 0.05, planetGap: 0.18 },
+    { house: 9, xPad: 0.02, yPad: 0.05, planetGap: 0.27 },
+    { house: 10, xPad: 0.02, yPad: 0.05, planetGap: 0.27 },
+    { house: 11, xPad: 0.02, yPad: 0.05, planetGap: 0.27 },
+    { house: 12, xPad: 0.02, yPad: 0.05, planetGap: 0.1 },
+  ]);
+});


### PR DESCRIPTION
## Summary
- render sign labels in a dedicated overlay with extra padding
- keep planets centered in higher z-index container
- add snapshot test ensuring labels avoid planets and borders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3eaa8c9f0832ba81a3c4947ee8b15