### PR TITLE
Add chart summary component and regression test

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import BirthForm from './components/BirthForm.jsx';
 import Chart from './components/Chart.jsx';
+import ChartSummary from './components/ChartSummary.jsx';
 import calculateChart from './calculateChart.js';
 
 export default function App() {
@@ -37,7 +38,12 @@ export default function App() {
             {error}
           </div>
         )}
-        {chartData && !loading && <Chart data={chartData} />}
+        {chartData && !loading && (
+          <div>
+            <Chart data={chartData} />
+            <ChartSummary data={chartData} />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/components/ChartSummary.jsx
+++ b/src/components/ChartSummary.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { summarizeChart } from '../lib/summary.js';
+
+export default function ChartSummary({ data }) {
+  const { ascendant, moonSign, houses } = summarizeChart(data);
+  return (
+    <div className="backdrop-blur-md bg-amber-50 border border-amber-200 rounded-xl p-6 text-amber-900 mt-4">
+      <p>Ascendant: {ascendant}</p>
+      <p>Moon sign: {moonSign}</p>
+      <table className="mt-4 text-left">
+        <tbody>
+          {houses.slice(1).map((planets, idx) => (
+            <tr key={idx}>
+              <td className="pr-2">House {idx + 1}</td>
+              <td>{planets}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+ChartSummary.propTypes = {
+  data: PropTypes.shape({
+    ascSign: PropTypes.number.isRequired,
+    planets: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        sign: PropTypes.number,
+        house: PropTypes.number.isRequired,
+      })
+    ).isRequired,
+  }).isRequired,
+};

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -35,6 +35,20 @@ export const SIGN_ABBREVIATIONS = [
   'Aq',
   'Pi',
 ];
+export const SIGN_NAMES = [
+  'Aries',
+  'Taurus',
+  'Gemini',
+  'Cancer',
+  'Leo',
+  'Virgo',
+  'Libra',
+  'Scorpio',
+  'Sagittarius',
+  'Capricorn',
+  'Aquarius',
+  'Pisces',
+];
 
 export function getSignLabel(index, { useAbbreviations = false } = {}) {
   const labels = useAbbreviations ? SIGN_ABBREVIATIONS : SIGN_NUMBERS;

--- a/src/lib/summary.js
+++ b/src/lib/summary.js
@@ -1,0 +1,27 @@
+import { SIGN_NAMES } from './astro.js';
+
+const PLANET_ABBR = {
+  sun: 'Su',
+  moon: 'Mo',
+  mars: 'Ma',
+  mercury: 'Me',
+  jupiter: 'Ju',
+  venus: 'Ve',
+  saturn: 'Sa',
+  rahu: 'Ra',
+  ketu: 'Ke',
+};
+
+export function summarizeChart(data) {
+  const ascendant = SIGN_NAMES[data.ascSign - 1];
+  const moon = data.planets.find((p) => p.name === 'moon');
+  const moonSign = SIGN_NAMES[(moon?.sign ?? 1) - 1];
+  const houses = Array.from({ length: 13 }, () => '');
+  for (let h = 1; h <= 12; h++) {
+    const abbrs = data.planets
+      .filter((p) => p.house === h)
+      .map((p) => PLANET_ABBR[p.name] || p.name.slice(0, 2));
+    houses[h] = abbrs.join(' ');
+  }
+  return { ascendant, moonSign, houses };
+}

--- a/tests/chart-summary-regression.test.js
+++ b/tests/chart-summary-regression.test.js
@@ -1,0 +1,28 @@
+const assert = require('node:assert');
+const test = require('node:test');
+const { computePositions } = require('../src/lib/astro.js');
+const { summarizeChart } = require('../src/lib/summary.js');
+
+test('Chart summary for reference chart matches expected output', async () => {
+  const data = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
+  const summary = summarizeChart(data);
+  assert.deepStrictEqual(summary, {
+    ascendant: 'Libra',
+    moonSign: 'Aries',
+    houses: [
+      '',
+      'Sa',
+      'Su Ju',
+      'Ke',
+      '',
+      '',
+      'Ma',
+      'Me Ve',
+      'Mo',
+      'Ra',
+      '',
+      '',
+      '',
+    ],
+  });
+});


### PR DESCRIPTION
## Summary
- Add list of zodiac sign names for easier textual summaries
- Introduce ChartSummary component and summary helper to show ascendant, moon sign, and house planets
- Render chart summary under the chart and add regression test for reference data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3ebed5240832bacbfd53cdeb2d7ff