### PR TITLE
Fix ascendant sign handling for house cusps

### DIFF
--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -169,11 +169,13 @@ export async function computePositions(dtISOWithZone, lat, lon) {
     lon,
   });
 
-  // Derive sign numbers (1–12) for each house directly from the cusp
-  // longitudes returned by Swiss Ephemeris. The `houses` array is 1-indexed
+  const ascSign = base.ascSign;
+
+  // Derive sign numbers (1–12) for each house directly from the returned
+  // cusp longitudes without any rotation. The `houses` array is 1-indexed
   // with index 1 representing the ascendant.
   const signInHouse = [null];
-  for (let h = 1; h <= 12; h++) {
+  for (let h = 1; h <= 12; h += 1) {
     signInHouse[h] = lonToSignDeg(base.houses[h]).sign;
   }
   if (process.env.DEBUG_HOUSES) {
@@ -233,7 +235,7 @@ export async function computePositions(dtISOWithZone, lat, lon) {
     });
   }
 
-  return { ascSign: base.ascSign, signInHouse, planets };
+  return { ascSign, signInHouse, planets };
 }
 
 export function renderNorthIndian(svgEl, data, options = {}) {

--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -23,7 +23,8 @@ export function lonToSignDeg(longitude) {
 }
 
 function toUTC({ datetime, zone }) {
-  const dt = DateTime.fromISO(datetime, { zone });
+  // Interpret the local time in the provided zone and convert to UTC.
+  const dt = DateTime.fromISO(datetime, { zone }).toUTC();
   return dt.toJSDate();
 }
 
@@ -46,8 +47,8 @@ export function compute_positions({ datetime, tz, lat, lon }, swe = swisseph) {
 
   const rawHouses = swe.swe_houses_ex(
     jd,
-    lat,
-    lon,
+    Number(lat),
+    Number(lon),
     'P',
     swe.SEFLG_SIDEREAL | swe.SEFLG_SWIEPH
   );
@@ -62,9 +63,9 @@ export function compute_positions({ datetime, tz, lat, lon }, swe = swisseph) {
   if (process.env.DEBUG_HOUSES) {
     console.log('swe_houses_ex houses:', houses);
   }
-  // The house array follows the Swiss Ephemeris convention: index 1 is the
-  // first house cusp (ascendant) and 12 the twelfth. Index 0 is unused.
-  const asc = lonToSignDeg(houses[1]);
+  // The house array follows the Swiss Ephemeris convention: index 1 is the
+  // first house cusp (ascendant) and 12 the twelfth. Index 0 is unused.
+  const ascSign = lonToSignDeg(rawHouses.ascendant).sign;
 
   const flag = swe.SEFLG_SWIEPH | swe.SEFLG_SPEED | swe.SEFLG_SIDEREAL;
   const planetCodes = {
@@ -118,5 +119,5 @@ export function compute_positions({ datetime, tz, lat, lon }, swe = swisseph) {
     house: houseOf(ketuLon),
   });
 
-  return { ascSign: asc.sign, houses, planets };
+  return { ascSign, houses, planets };
 }

--- a/tests/darbhanga-dec-1982.test.js
+++ b/tests/darbhanga-dec-1982.test.js
@@ -4,6 +4,11 @@ const { computePositions } = require('../src/lib/astro.js');
 
 test('Darbhanga 1982-12-01 03:50 positions', async () => {
   const res = await computePositions('1982-12-01T03:50+05:30', 26.15216, 85.89707);
+  assert.strictEqual(res.ascSign, 7);
+  assert.deepStrictEqual(
+    res.signInHouse.slice(1),
+    [7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6]
+  );
   const planets = Object.fromEntries(res.planets.map((p) => [p.name, p]));
   assert.strictEqual(planets.moon.house, 8);
   assert.strictEqual(planets.mars.house, 6);


### PR DESCRIPTION
## Summary
- convert local time to UTC before calling Swiss Ephemeris and ensure numeric lat/lon
- expose ascendant sign directly and derive house sign sequence from cusp longitudes
- add regression test for Darbhanga December 1982 ensuring ascendant sign and house order

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3ee9334e8832bb8bf74193f38b5cf