### PR TITLE
Ensure planetary houses stay in range

### DIFF
--- a/tests/darbhanga-dec-1982.test.js
+++ b/tests/darbhanga-dec-1982.test.js
@@ -10,7 +10,18 @@ test('Darbhanga 1982-12-01 03:50 positions', async () => {
     [7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6]
   );
   const planets = Object.fromEntries(res.planets.map((p) => [p.name, p]));
-  assert.strictEqual(planets.moon.house, 8);
-  assert.strictEqual(planets.mars.house, 6);
-  assert.strictEqual(planets.ketu.house, 3);
+  const expected = {
+    sun: 2,
+    moon: 8,
+    mercury: 7,
+    venus: 7,
+    mars: 6,
+    jupiter: 2,
+    saturn: 1,
+    rahu: 9,
+    ketu: 3,
+  };
+  for (const [name, house] of Object.entries(expected)) {
+    assert.strictEqual(planets[name].house, house, `${name} house`);
+  }
 });


### PR DESCRIPTION
## Summary
- Normalize Swiss Ephemeris house positions to 1–12 to avoid cusp drift
- Recompute Darbhanga sample and verify each planet’s house assignment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3efffb544832b8a330b0d55249cee