### PR TITLE
test: verify positions against AstroSage

### DIFF
--- a/tests/astroComparison.test.js
+++ b/tests/astroComparison.test.js
@@ -1,42 +1,126 @@
 const assert = require('node:assert');
 const test = require('node:test');
-const { computePositions } = require('../src/lib/astro.js');
+const { computePositions, renderNorthIndian } = require('../src/lib/astro.js');
 
-// Reference chart generated with AstroSage for
-// Darbhanga, India on 1982-12-01 at 03:50 (UTC+5:30)
-// Signs are 0=Aries .. 11=Pisces; houses are 1..12.
-const reference = {
-  sun: { sign: 7, house: 2 },
-  moon: { sign: 1, house: 8 },
-  mars: { sign: 11, house: 6 },
-  mercury: { sign: 0, house: 7 },
-  jupiter: { sign: 7, house: 2 },
-  venus: { sign: 0, house: 7 },
-  saturn: { sign: 6, house: 1 },
-  rahu: { sign: 2, house: 9 },
-  ketu: { sign: 8, house: 3 },
-};
-
-test('computePositions matches AstroSage reference for Darbhanga 1982-12-01 03:50', async () => {
-  const result = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
-  assert.strictEqual(result.ascSign, 7);
-  assert.deepStrictEqual(
-    result.planets.filter((p) => p.house === 7).map((p) => p.name),
-    ['mercury', 'venus']
-  );
-  const planets = Object.fromEntries(result.planets.map((p) => [p.name, p]));
-  const rows = Object.keys(reference).map((name) => ({
-    planet: name,
-    expectedSign: reference[name].sign,
-    actualSign: planets[name].sign,
-    expectedHouse: reference[name].house,
-    actualHouse: planets[name].house,
-  }));
-
-  console.table(rows);
-
-  for (const row of rows) {
-    assert.strictEqual(row.actualSign, row.expectedSign, `${row.planet} sign`);
-    assert.strictEqual(row.actualHouse, row.expectedHouse, `${row.planet} house`);
+class Element {
+  constructor(tag) {
+    this.tagName = tag;
+    this.attributes = {};
+    this.children = [];
+    this.textContent = '';
   }
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+  }
+  appendChild(child) {
+    this.children.push(child);
+  }
+  removeChild(child) {
+    const i = this.children.indexOf(child);
+    if (i >= 0) this.children.splice(i, 1);
+  }
+  get firstChild() {
+    return this.children[0];
+  }
+}
+
+const doc = { createElementNS: (ns, tag) => new Element(tag) };
+
+test('computePositions matches AstroSage for Darbhanga 1982-12-01 03:50', async () => {
+  const result = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
+
+  // Ascendant sign
+  assert.strictEqual(result.ascSign, 7);
+
+  // Sign sequence (sign in each house)
+  assert.deepStrictEqual(result.signInHouse, [null, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6]);
+
+  // Expected house placement for each planet
+  const planets = Object.fromEntries(result.planets.map((p) => [p.name, p]));
+  const expectedHouses = {
+    sun: 2,
+    moon: 8,
+    mars: 6,
+    mercury: 7,
+    jupiter: 2,
+    venus: 7,
+    saturn: 1,
+    rahu: 9,
+    ketu: 3,
+  };
+  for (const [name, house] of Object.entries(expectedHouses)) {
+    assert.strictEqual(planets[name].house, house, `${name} house`);
+  }
+
+  // Retrograde flags
+  const expectedRetro = {
+    sun: false,
+    moon: false,
+    mars: false,
+    mercury: true,
+    jupiter: true,
+    venus: false,
+    saturn: true,
+    rahu: true,
+    ketu: true,
+  };
+  for (const [name, retro] of Object.entries(expectedRetro)) {
+    assert.strictEqual(planets[name].retro, retro, `${name} retrograde`);
+  }
+
+  // Combustion states
+  const expectedCombust = {
+    sun: false,
+    moon: false,
+    mars: false,
+    mercury: false,
+    jupiter: true,
+    venus: false,
+    saturn: false,
+    rahu: false,
+    ketu: false,
+  };
+  for (const [name, combust] of Object.entries(expectedCombust)) {
+    assert.strictEqual(planets[name].combust, combust, `${name} combust`);
+  }
+
+  // Render chart and compare snapshot to guard against layout regressions
+  global.document = doc;
+  const svg = new Element('svg');
+  renderNorthIndian(svg, result);
+  delete global.document;
+  const snapshot = svg.children.map((c) => ({
+    tag: c.tagName,
+    attrs: c.attributes,
+    text: c.textContent,
+  }));
+  assert.deepStrictEqual(snapshot, [
+    { tag: 'path', attrs: { d: 'M0 0 L1 0 L1 1 L0 1 Z', 'stroke-width': '0.02' }, text: '' },
+    { tag: 'path', attrs: { d: 'M0 0 L1 1', 'stroke-width': '0.01' }, text: '' },
+    { tag: 'path', attrs: { d: 'M1 0 L0 1', 'stroke-width': '0.01' }, text: '' },
+    { tag: 'path', attrs: { d: 'M0.5 0 L1 0.5 L0.5 1 L0 0.5 Z', 'stroke-width': '0.01' }, text: '' },
+    { tag: 'text', attrs: { x: '0.27', y: '0.05', 'text-anchor': 'start', 'font-size': '0.03' }, text: 'Asc' },
+    { tag: 'text', attrs: { x: '0.73', y: '0.05', 'text-anchor': 'end', 'font-size': '0.05' }, text: '7' },
+    { tag: 'text', attrs: { x: '0.48', y: '0.05', 'text-anchor': 'end', 'font-size': '0.05' }, text: '8' },
+    { tag: 'text', attrs: { x: '0.23', y: '0.05', 'text-anchor': 'end', 'font-size': '0.05' }, text: '9' },
+    { tag: 'text', attrs: { x: '0.48', y: '0.3', 'text-anchor': 'end', 'font-size': '0.05' }, text: '10' },
+    { tag: 'text', attrs: { x: '0.23', y: '0.55', 'text-anchor': 'end', 'font-size': '0.05' }, text: '11' },
+    { tag: 'text', attrs: { x: '0.48', y: '0.8', 'text-anchor': 'end', 'font-size': '0.05' }, text: '12' },
+    { tag: 'text', attrs: { x: '0.73', y: '0.55', 'text-anchor': 'end', 'font-size': '0.05' }, text: '1' },
+    { tag: 'text', attrs: { x: '0.98', y: '0.8', 'text-anchor': 'end', 'font-size': '0.05' }, text: '2' },
+    { tag: 'text', attrs: { x: '0.98', y: '0.55', 'text-anchor': 'end', 'font-size': '0.05' }, text: '3' },
+    { tag: 'text', attrs: { x: '0.98', y: '0.3', 'text-anchor': 'end', 'font-size': '0.05' }, text: '4' },
+    { tag: 'text', attrs: { x: '0.98', y: '0.05', 'text-anchor': 'end', 'font-size': '0.05' }, text: '5' },
+    { tag: 'text', attrs: { x: '0.98', y: '0.05', 'text-anchor': 'end', 'font-size': '0.05' }, text: '6' },
+    { tag: 'text', attrs: { x: '0.5', y: '0.32', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "saturn(R)(Ex) 00°14'" },
+    { tag: 'text', attrs: { x: '0.25', y: '0.15333333333333332', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "sun 14°46'" },
+    { tag: 'text', attrs: { x: '0.25', y: '0.19333333333333333', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "jupiter(R)(C) 05°04'" },
+    { tag: 'text', attrs: { x: '0.08333333333333333', y: '0.32', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "ketu(R) 11°53'" },
+    { tag: 'text', attrs: { x: '0.25', y: '0.98', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "mars 08°07'" },
+    { tag: 'text', attrs: { x: '0.5', y: '0.8200000000000001', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "mercury(R) 29°13'" },
+    { tag: 'text', attrs: { x: '0.5', y: '0.8600000000000001', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "venus 10°02'" },
+    { tag: 'text', attrs: { x: '0.75', y: '0.98', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "moon(Ex) 13°17'" },
+    { tag: 'text', attrs: { x: '0.9166666666666666', y: '0.8200000000000001', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "rahu(R) 11°53'" },
+  ]);
 });
+


### PR DESCRIPTION
## Summary
- add regression test comparing 1982-12-01 chart to AstroSage
- verify ascendant, sign order, planetary houses, retrograde, and combustion flags
- snapshot rendered chart to prevent sign label or empty-house layout regressions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3fc601be4832b8df780b2a7e53ddb