### PR TITLE
Simplify house sign derivation

### DIFF
--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon';
-import { compute_positions, lonToSignDeg } from './ephemeris.js';
+import { compute_positions } from './ephemeris.js';
 
 const svgNS = 'http://www.w3.org/2000/svg';
 
@@ -171,12 +171,11 @@ export async function computePositions(dtISOWithZone, lat, lon) {
 
   const ascSign = base.ascSign;
 
-  // Derive sign numbers (1–12) for each house directly from the returned
-  // cusp longitudes without any rotation. The `houses` array is 1-indexed
-  // with index 1 representing the ascendant.
+  // Derive sign numbers (1–12) for each house from the ascendant. Houses
+  // progress counter-clockwise so each subsequent house increments the sign.
   const signInHouse = [null];
   for (let h = 1; h <= 12; h += 1) {
-    signInHouse[h] = lonToSignDeg(base.houses[h]).sign;
+    signInHouse[h] = ((ascSign + h - 2) % 12) + 1;
   }
   if (process.env.DEBUG_HOUSES) {
     console.log('signInHouse:', signInHouse);

--- a/tests/sign-in-house-sequence.test.js
+++ b/tests/sign-in-house-sequence.test.js
@@ -5,6 +5,10 @@ const { computePositions } = require('../src/lib/astro.js');
 test('Darbhanga 1982-12-01 03:50 ascendant and sign sequence', async () => {
   const result = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
   assert.strictEqual(result.ascSign, 7);
-  const expected = [null, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6];
-  assert.deepStrictEqual(result.signInHouse, expected);
+  assert.strictEqual(result.signInHouse[1], result.ascSign);
+  for (let h = 1; h <= 12; h++) {
+    const next = (h % 12) + 1;
+    const expected = (result.signInHouse[h] % 12) + 1;
+    assert.strictEqual(result.signInHouse[next], expected);
+  }
 });


### PR DESCRIPTION
## Summary
- Derive house sign sequence directly from the ascendant instead of cusp longitudes
- Remove unused `lonToSignDeg` import
- Add regression test ensuring house signs start at ascendant and progress counter-clockwise

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b403fd45c4832b8a9e3f601810d663