### PR TITLE
Fix Moon sign calculation and add test

### DIFF
--- a/src/lib/summary.js
+++ b/src/lib/summary.js
@@ -15,7 +15,7 @@ const PLANET_ABBR = {
 export function summarizeChart(data) {
   const ascendant = SIGN_NAMES[data.ascSign - 1];
   const moon = data.planets.find((p) => p.name === 'moon');
-  const moonSign = SIGN_NAMES[(moon?.sign ?? 1) - 1];
+  const moonSign = SIGN_NAMES[moon?.sign ?? 0];
   const houses = Array.from({ length: 13 }, () => '');
   for (let h = 1; h <= 12; h++) {
     const abbrs = data.planets

--- a/tests/chart-summary-regression.test.js
+++ b/tests/chart-summary-regression.test.js
@@ -8,7 +8,7 @@ test('Chart summary for reference chart matches expected output', async () => {
   const summary = summarizeChart(data);
   assert.deepStrictEqual(summary, {
     ascendant: 'Libra',
-    moonSign: 'Aries',
+    moonSign: 'Taurus',
     houses: [
       '',
       'Sa',

--- a/tests/moon-sign.test.js
+++ b/tests/moon-sign.test.js
@@ -1,0 +1,10 @@
+const assert = require('node:assert');
+const test = require('node:test');
+const { computePositions } = require('../src/lib/astro.js');
+const { summarizeChart } = require('../src/lib/summary.js');
+
+test('Moon sign for sample chart is Taurus', async () => {
+  const data = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
+  const summary = summarizeChart(data);
+  assert.strictEqual(summary.moonSign, 'Taurus');
+});


### PR DESCRIPTION
## Summary
- compute Moon sign using zero-based index
- update chart summary regression and add dedicated Moon sign test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b408c9ff54832b9ccfec85a5c043e0