### PR TITLE
Use numeric coordinates when calculating houses

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -84,7 +84,14 @@ export function compute_positions({ datetime, tz, lat, lon }, swe = swisseph) {
   const rahuFlags = rahuData.flags || 0;
   const { sign: rSign, deg: rDeg } = lonToSignDeg(rahuData.longitude);
   const houseOf = (bodyLon) => {
-    const rawHouse = swe.swe_house_pos(jd, lat, lon, 'P', bodyLon, houses);
+    const rawHouse = swe.swe_house_pos(
+      jd,
+      Number(lat),
+      Number(lon),
+      'P',
+      bodyLon,
+      houses
+    );
     // Normalize to 1–12 to prevent cusp drift (e.g. 0 or 13)
     return ((Math.floor(rawHouse) - 1 + 12) % 12) + 1; // 1..12
   };


### PR DESCRIPTION
## Summary
- Cast latitude and longitude to numbers before calling `swe_house_pos`

## Testing
- `npm test tests/mercury-venus-mars-houses.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b42551dbd8832ba477a83322867015