### PR TITLE
Improve sign label spacing and add clarity test

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -86,7 +86,7 @@ export default function Chart({
           const width = (maxX - minX) * size - margin;
           const height = (maxY - minY) * size - margin;
 
-          const labelPad = (4 / 300) * size;
+          const labelPad = (8 / 300) * size;
           return (
             <div
               key={houseNum}
@@ -104,14 +104,14 @@ export default function Chart({
                 className="absolute inset-0 pointer-events-none z-0"
                 style={{ padding: labelPad }}
               >
-                <div className="absolute top-0 right-0">
+                <div className="absolute top-1 right-1">
                   <span className="text-amber-700 font-bold text-[clamp(0.9rem,1.5vw,1.2rem)] leading-none">
                     {getSignLabel(signNum - 1, { useAbbreviations })}
                   </span>
                 </div>
 
                 {houseNum === 1 && (
-                  <div className="absolute top-0 left-0">
+                  <div className="absolute top-1 left-1">
                     <span className="text-amber-700 text-[0.7rem] font-semibold leading-none">
                       Asc
                     </span>

--- a/tests/sign-number-clear.test.js
+++ b/tests/sign-number-clear.test.js
@@ -1,0 +1,79 @@
+const assert = require('node:assert');
+const test = require('node:test');
+const { renderNorthIndian, HOUSE_BBOXES } = require('../src/lib/astro.js');
+
+class Element {
+  constructor(tag) {
+    this.tagName = tag;
+    this.attributes = {};
+    this.children = [];
+    this.textContent = '';
+  }
+  setAttribute(name, value) {
+    this.attributes[name] = String(value);
+  }
+  appendChild(child) {
+    this.children.push(child);
+  }
+  removeChild(child) {
+    const i = this.children.indexOf(child);
+    if (i >= 0) this.children.splice(i, 1);
+  }
+  get firstChild() {
+    return this.children[0];
+  }
+}
+
+const doc = { createElementNS: (ns, tag) => new Element(tag) };
+
+test('sign numbers remain clear and non-overlapping', () => {
+  const signInHouse = [null];
+  for (let h = 1; h <= 12; h++) signInHouse[h] = h;
+  const planets = [];
+  for (let h = 1; h <= 12; h++) {
+    planets.push({ name: `p${h}a`, house: h, deg: 0 });
+    planets.push({ name: `p${h}b`, house: h, deg: 10 });
+  }
+
+  global.document = doc;
+  const svg = new Element('svg');
+  renderNorthIndian(svg, { ascSign: 1, signInHouse, planets });
+  delete global.document;
+
+  const texts = svg.children.filter((c) => c.tagName === 'text');
+  const snapshot = [];
+
+  for (let h = 1; h <= 12; h++) {
+    const bbox = HOUSE_BBOXES[h - 1];
+    const signNode = texts.find((t) => t.textContent === String(h));
+    assert.ok(signNode, `missing sign label for house ${h}`);
+    const sx = Number(signNode.attributes.x);
+    const sy = Number(signNode.attributes.y);
+    const xPad = +(bbox.maxX - sx).toFixed(2);
+    const yPad = +(sy - bbox.minY).toFixed(2);
+    const planetYs = texts
+      .filter((t) => t.textContent.startsWith(`p${h}`))
+      .map((t) => Number(t.attributes.y));
+    const minPlanetY = Math.min(...planetYs);
+    const gap = +(minPlanetY - sy).toFixed(2);
+
+    snapshot.push({ house: h, xPad, yPad, planetGap: gap });
+    assert.ok(gap >= 0.02, `label overlaps planet in house ${h}`);
+  }
+
+  assert.deepStrictEqual(snapshot, [
+    { house: 1, xPad: 0.02, yPad: 0.05, planetGap: 0.1 },
+    { house: 2, xPad: 0.02, yPad: 0.05, planetGap: 0.1 },
+    { house: 3, xPad: 0.02, yPad: 0.05, planetGap: 0.27 },
+    { house: 4, xPad: 0.02, yPad: 0.05, planetGap: 0.27 },
+    { house: 5, xPad: 0.02, yPad: 0.05, planetGap: 0.27 },
+    { house: 6, xPad: 0.02, yPad: 0.05, planetGap: 0.18 },
+    { house: 7, xPad: 0.02, yPad: 0.05, planetGap: 0.27 },
+    { house: 8, xPad: 0.02, yPad: 0.05, planetGap: 0.18 },
+    { house: 9, xPad: 0.02, yPad: 0.05, planetGap: 0.27 },
+    { house: 10, xPad: 0.02, yPad: 0.05, planetGap: 0.27 },
+    { house: 11, xPad: 0.02, yPad: 0.05, planetGap: 0.27 },
+    { house: 12, xPad: 0.02, yPad: 0.05, planetGap: 0.1 },
+  ]);
+});
+


### PR DESCRIPTION
## Summary
- increase chart sign label padding and offset labels from edges
- keep sign numbers beneath planet listings to avoid overlap
- add snapshot test ensuring sign numbers stay clear of planets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b429d6e5c8832b8df0f2232b174ed7