### PR TITLE
Use Swiss Ephemeris retrograde flag

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -50,7 +50,7 @@ export default function Chart({
       degree = `${d}°${String(m).padStart(2, '0')}'`;
     }
     let abbr = PLANET_ABBR[p.name.toLowerCase()] || p.name.slice(0, 2);
-    const isRetro = Boolean(p.retro);
+    const isRetro = p.retro;
     if (isRetro) abbr += '(R)';
     if (p.combust) abbr += '(C)';
     if (p.exalted) abbr += '(Ex)';

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -212,7 +212,7 @@ export async function computePositions(dtISOWithZone, lat, lon) {
     const house = p.house;
     const deg = p.deg;
     const lon = sign * 30 + deg;
-    const retro = Boolean(p.retro);
+    const retro = p.retro;
     const cDeg = combustDeg[p.name];
     let combust = false;
     if (cDeg !== undefined) {

--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -100,7 +100,7 @@ export function compute_positions({ datetime, tz, lat, lon }, swe = swisseph) {
     const { sign, deg } =
       name === 'rahu' ? { sign: rSign, deg: rDeg } : lonToSignDeg(data.longitude);
     const flags = name === 'rahu' ? rahuFlags : data.flags || 0;
-    const retro = data.longitudeSpeed <= -1e-4;
+    const retro = (flags & swe.SEFLG_RETROGRADE) !== 0;
     planets.push({
       name,
       sign,
@@ -117,7 +117,7 @@ export function compute_positions({ datetime, tz, lat, lon }, swe = swisseph) {
   if (((kSign - rSign + 12) % 12) !== 6) {
     throw new Error('Rahu and Ketu must be six signs apart');
   }
-  const ketuRetro = rahuData.longitudeSpeed <= -1e-4;
+  const ketuRetro = (rahuFlags & swe.SEFLG_RETROGRADE) !== 0;
   planets.push({
     name: 'ketu',
     sign: kSign,

--- a/tests/planet-flags.test.js
+++ b/tests/planet-flags.test.js
@@ -28,3 +28,15 @@ test('exalted label includes (Ex)', () => {
   assert.ok(label.startsWith('Ju(Ex)'));
 });
 
+test('sample planets are direct by default', () => {
+  const sample = [
+    { abbr: 'Su', degree: 0 },
+    { abbr: 'Mo', degree: 15.5 },
+    { abbr: 'Ma', degree: 27 },
+  ];
+  for (const p of sample) {
+    const label = buildLabel(p);
+    assert.ok(!label.includes('(R)'), `${p.abbr} should be direct`);
+  }
+});
+


### PR DESCRIPTION
## Summary
- Derive retrograde status directly from Swiss Ephemeris flags
- Propagate retrograde boolean through chart calculations and rendering
- Ensure sample planets are flagged direct in label tests

## Testing
- `npm test` *(fails: Darbhanga ascendant regression, AstroSage comparisons, chart summary regression, reference chart house checks)*

------
https://chatgpt.com/codex/tasks/task_e_68b43b88f214832bbdc238c89f001171