### PR TITLE
Derive sign sequence from ascendant

### DIFF
--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -1,5 +1,5 @@
 import { DateTime } from 'luxon';
-import { compute_positions, lonToSignDeg } from './ephemeris.js';
+import { compute_positions } from './ephemeris.js';
 
 const svgNS = 'http://www.w3.org/2000/svg';
 
@@ -169,11 +169,11 @@ export async function computePositions(dtISOWithZone, lat, lon) {
     lon,
   });
 
+  const ascSign = base.ascSign;
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) {
-    signInHouse[h] = lonToSignDeg(base.houses[h]).sign;
+    signInHouse[h] = ((ascSign + h - 2) % 12) + 1;
   }
-  const ascSign = signInHouse[1];
   if (process.env.DEBUG_HOUSES) {
     console.log('signInHouse:', signInHouse);
   }

--- a/tests/sign-in-house-sequence.test.js
+++ b/tests/sign-in-house-sequence.test.js
@@ -8,3 +8,10 @@ test('Darbhanga 1982-12-01 03:50 ascendant and sign sequence', async () => {
   assert.strictEqual(result.signInHouse[1], result.ascSign);
   assert.deepStrictEqual(result.signInHouse, [null, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6]);
 });
+
+test('Darbhanga 1982-12-01 15:50 ascendant and sign sequence', async () => {
+  const result = await computePositions('1982-12-01T15:50+05:30', 26.152, 85.897);
+  assert.strictEqual(result.ascSign, 2);
+  assert.strictEqual(result.signInHouse[1], result.ascSign);
+  assert.deepStrictEqual(result.signInHouse, [null, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 1]);
+});


### PR DESCRIPTION
## Summary
- derive ascendant sign directly from ephemeris output
- compute house sign sequence from ascendant instead of cusp longitudes
- add regression coverage for morning and afternoon sign sequences

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b44bdc9b20832b9baa12faa6aad4ac