### PR TITLE
Ensure summarizeChart iterates 1-12 and add houses regression test

### DIFF
--- a/src/lib/summary.js
+++ b/src/lib/summary.js
@@ -16,12 +16,13 @@ export function summarizeChart(data) {
   const ascendant = SIGN_NAMES[data.ascSign - 1];
   const moon = data.planets.find((p) => p.name === 'moon');
   const moonSign = SIGN_NAMES[moon?.sign ?? 0];
-  const houses = Array.from({ length: 13 }, () => '');
-  for (let h = 1; h <= 12; h++) {
-    const abbrs = data.planets
+  // keep index 0 empty so houses are 1‑indexed
+  const houses = Array(13).fill('');
+  for (let h = 1; h <= 12; h += 1) {
+    houses[h] = data.planets
       .filter((p) => p.house === h)
-      .map((p) => PLANET_ABBR[p.name] || p.name.slice(0, 2));
-    houses[h] = abbrs.join(' ');
+      .map((p) => PLANET_ABBR[p.name] || p.name.slice(0, 2))
+      .join(' ');
   }
   return { ascendant, moonSign, houses };
 }

--- a/tests/chart-summary-houses.test.js
+++ b/tests/chart-summary-houses.test.js
@@ -1,0 +1,11 @@
+const assert = require('node:assert');
+const test = require('node:test');
+const { computePositions } = require('../src/lib/astro.js');
+const { summarizeChart } = require('../src/lib/summary.js');
+
+test('houses 6-7 list expected planets for reference chart', async () => {
+  const data = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
+  const summary = summarizeChart(data);
+  assert.strictEqual(summary.houses[6], 'Ma');
+  assert.strictEqual(summary.houses[7], 'Me Ve');
+});


### PR DESCRIPTION
## Summary
- Keep houses array 1-indexed in `summarizeChart` and iterate through all 12 houses
- Add regression test confirming houses 6-7 summarize correct planets for reference chart

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4506caabc832b885d366d70490bcd