### PR TITLE
feat: pad sign labels from frame

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -81,7 +81,10 @@ export default function Chart({
     };
   });
 
-  const labelPad = (12 / 300) * size;
+  // Extra padding ensures the sign labels don't hug the chart frame
+  // and stay clear of any planet text. Empirically a slightly wider
+  // margin works well across chart sizes.
+  const labelPad = (20 / 300) * size;
 
   return (
     <div className="backdrop-blur-md bg-amber-50 border border-amber-200 rounded-xl p-6 flex items-center justify-center">

--- a/tests/sign-label-padding.test.js
+++ b/tests/sign-label-padding.test.js
@@ -63,11 +63,13 @@ test('sign labels keep padding from borders and planets', () => {
 
     const xPad = +(bbox.maxX - signX).toFixed(2);
     const yPad = +(signY - bbox.minY).toFixed(2);
+    const touchesFrame = xPad < 0.04 || yPad < 0.08;
+    const overlapsPlanet = gap !== null && gap < 0.02;
+
     snapshot.push({ house: h, xPad, yPad, planetGap: gap });
 
-    assert.ok(xPad >= 0.04, 'label touches right border');
-    assert.ok(yPad >= 0.08, 'label touches top border');
-    if (gap !== null) assert.ok(gap >= 0.02, 'label overlaps planet');
+    assert.ok(!touchesFrame, 'label touches frame');
+    assert.ok(!overlapsPlanet, 'label overlaps planet');
   }
 
   assert.deepStrictEqual(snapshot, [

--- a/tests/sign-label-position.test.js
+++ b/tests/sign-label-position.test.js
@@ -30,32 +30,55 @@ test('sign labels anchor to chart corners with padding', () => {
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) signInHouse[h] = h;
 
+  const planets = [];
+  for (let h = 1; h <= 12; h++) {
+    planets.push({ name: `p${h}`, house: h, deg: 0 });
+  }
+
   global.document = doc;
   const svg = new Element('svg');
-  renderNorthIndian(svg, { ascSign: 1, signInHouse, planets: [] });
+  renderNorthIndian(svg, { ascSign: 1, signInHouse, planets });
   delete global.document;
 
-  const texts = svg.children.filter(
-    (c) => c.tagName === 'text' && c.attributes['font-size'] === '0.05'
+  const texts = svg.children.filter((c) => c.tagName === 'text');
+  const signNodes = texts.filter(
+    (c) => c.attributes['font-size'] === '0.05'
   );
-  assert.strictEqual(texts.length, 12);
+  assert.strictEqual(signNodes.length, 12);
 
   const snapshot = [];
   for (let h = 1; h <= 12; h++) {
     const bbox = HOUSE_BBOXES[h - 1];
-    const node = texts[h - 1];
+    const node = signNodes[h - 1];
     const x = Number(node.attributes.x);
     const y = Number(node.attributes.y);
     const xPad = +(bbox.maxX - x).toFixed(2);
     const yPad = +(y - bbox.minY).toFixed(2);
-    snapshot.push({ house: h, xPad, yPad });
-    assert.ok(xPad >= 0.04, 'label touches right border');
-    assert.ok(yPad >= 0.08, 'label touches top border');
+    const planetNodes = texts.filter((t) =>
+      t.textContent.startsWith(`p${h} `)
+    );
+    const planetYs = planetNodes.map((t) => Number(t.attributes.y));
+    const minPlanetY = planetYs.length ? Math.min(...planetYs) : null;
+    const gap = minPlanetY !== null ? +(minPlanetY - y).toFixed(2) : null;
+    snapshot.push({ house: h, xPad, yPad, planetGap: gap });
+    const touchesFrame = xPad < 0.04 || yPad < 0.08;
+    assert.ok(!touchesFrame, 'label touches frame');
+    if (gap !== null) assert.ok(gap >= 0.02, 'label overlaps planet');
   }
 
-  assert.deepStrictEqual(
-    snapshot,
-    Array.from({ length: 12 }, (_, i) => ({ house: i + 1, xPad: 0.04, yPad: 0.08 }))
-  );
+  assert.deepStrictEqual(snapshot, [
+    { house: 1, xPad: 0.04, yPad: 0.08, planetGap: 0.24 },
+    { house: 2, xPad: 0.04, yPad: 0.08, planetGap: 0.07 },
+    { house: 3, xPad: 0.04, yPad: 0.08, planetGap: 0.24 },
+    { house: 4, xPad: 0.04, yPad: 0.08, planetGap: 0.24 },
+    { house: 5, xPad: 0.04, yPad: 0.08, planetGap: 0.24 },
+    { house: 6, xPad: 0.04, yPad: 0.08, planetGap: 0.15 },
+    { house: 7, xPad: 0.04, yPad: 0.08, planetGap: 0.24 },
+    { house: 8, xPad: 0.04, yPad: 0.08, planetGap: 0.15 },
+    { house: 9, xPad: 0.04, yPad: 0.08, planetGap: 0.24 },
+    { house: 10, xPad: 0.04, yPad: 0.08, planetGap: 0.24 },
+    { house: 11, xPad: 0.04, yPad: 0.08, planetGap: 0.24 },
+    { house: 12, xPad: 0.04, yPad: 0.08, planetGap: 0.07 },
+  ]);
 });
 


### PR DESCRIPTION
## Summary
- increase sign label padding in Chart component to avoid border collisions
- expand sign label tests to guard against touching the frame or overlapping planets

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b45a8e2ec4832b9d56f38e7a0ff84e