### PR TITLE
fix: correct Mars house test expectation

### DIFF
--- a/tests/mercury-venus-mars-houses.test.js
+++ b/tests/mercury-venus-mars-houses.test.js
@@ -12,5 +12,5 @@ test('Mercury/Venus in 2nd and Mars in 3rd house for reference chart', () => {
   const planets = Object.fromEntries(result.planets.map((p) => [p.name, p.house]));
   assert.strictEqual(planets.mercury, 2);
   assert.strictEqual(planets.venus, 2);
-    assert.strictEqual(planets.mars, 1);
-  });
+  assert.strictEqual(planets.mars, 3);
+});


### PR DESCRIPTION
## Summary
- fix Mercury/Venus/Mars house test to expect Mars in house 3

## Testing
- `npm test` *(fails: Expected values to be strictly equal: 1 !== 3)*

------
https://chatgpt.com/codex/tasks/task_e_68b4673320d4832b9eb3d2f07d0d1627