### PR TITLE
test: add sign sequence regression against AstroSage

### DIFF
--- a/tests/sign-sequence-astrosage.test.js
+++ b/tests/sign-sequence-astrosage.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { computePositions } = require('../src/lib/astro.js');
+
+test('sign sequence matches AstroSage for Darbhanga 1982-12-01 03:50', async () => {
+  const result = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
+  // Ascendant sign should populate the first house
+  assert.strictEqual(result.signInHouse[1], result.ascSign);
+  // The sequence should progress sequentially
+  assert.deepStrictEqual(result.signInHouse.slice(1), [7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6]);
+});


### PR DESCRIPTION
## Summary
- Ensure ascendant sign leads the sign-in-house sequence in computePositions
- Verify Chart component uses house/sign mapping correctly
- Add regression test for Darbhanga sign sequence against AstroSage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4870e2388832ba1e16f4ab5a40730