### PR TITLE
Ensure planet labels avoid sign labels

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -94,12 +94,29 @@ export default function Chart({
     const signNum = signInHouse[houseNum] ?? houseNum;
     const planets = planetByHouse[houseNum] || [];
     const signBottom = labelY + SIGN_FONT_SIZE / 2;
-    let py = Math.max(signBottom + PLANET_GAP, cy + 0.07);
-    if (py > maxPolyY - PLANET_PAD) py = maxPolyY - PLANET_PAD;
-    const step =
-      planets.length > 1
-        ? Math.min(0.04, (maxPolyY - PLANET_PAD - py) / (planets.length - 1))
-        : 0;
+    const bottomLimit = maxPolyY - PLANET_PAD;
+    let px = cx;
+    const baseline = cy + 0.07;
+    let py = signBottom + PLANET_GAP;
+    if (py < baseline) py = baseline;
+    let downward = true;
+    if (py > bottomLimit) {
+      py = bottomLimit;
+      downward = false;
+      const shift = 0.06;
+      px =
+        signX < cx
+          ? Math.min(maxX - PLANET_PAD, cx + shift)
+          : Math.max(minX + PLANET_PAD, cx - shift);
+    }
+    let step = 0;
+    if (planets.length > 1) {
+      const available = downward
+        ? bottomLimit - py
+        : py - (minY + PLANET_PAD);
+      step = available > 0 ? Math.min(0.04, available / (planets.length - 1)) : 0;
+      if (!downward) step = -step;
+    }
     return {
       houseNum,
       signNum,
@@ -107,7 +124,7 @@ export default function Chart({
       signY: labelY,
       ascX: minX + SIGN_PAD_X,
       planets,
-      cx,
+      cx: px,
       pyStart: py,
       step,
     };

--- a/tests/astroComparison.test.js
+++ b/tests/astroComparison.test.js
@@ -116,10 +116,10 @@ test('computePositions matches AstroSage for Darbhanga 1982-12-01 03:50', async 
     { tag: 'text', attrs: { x: '0.5', y: '0.32', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "jupiter(R) 25°04'" },
     { tag: 'text', attrs: { x: '0.25', y: '0.15333333333333332', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "sun 14°46'" },
     { tag: 'text', attrs: { x: '0.08333333333333333', y: '0.32', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "ketu(R) 11°53'" },
-    { tag: 'text', attrs: { x: '0.25', y: '0.98', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "mars 08°19'" },
+    { tag: 'text', attrs: { x: '0.19', y: '0.98', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "mars 08°19'" },
     { tag: 'text', attrs: { x: '0.5', y: '0.8200000000000001', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "mercury(R) 29°13'" },
     { tag: 'text', attrs: { x: '0.5', y: '0.8600000000000001', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "venus 10°02'" },
-    { tag: 'text', attrs: { x: '0.75', y: '0.98', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "moon(Ex) 13°17'" },
+    { tag: 'text', attrs: { x: '0.69', y: '0.98', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "moon(Ex) 13°17'" },
     { tag: 'text', attrs: { x: '0.9166666666666666', y: '0.8200000000000001', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "rahu(R) 11°53'" },
     { tag: 'text', attrs: { x: '0.75', y: '0.15333333333333332', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "saturn(R) 29°14'" },
   ]);

--- a/tests/chart-regression.test.js
+++ b/tests/chart-regression.test.js
@@ -116,10 +116,10 @@ test('computePositions matches AstroSage for Darbhanga 1982-12-01 03:50', async 
     { tag: 'text', attrs: { x: '0.5', y: '0.32', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "jupiter(R) 25°04'" },
     { tag: 'text', attrs: { x: '0.25', y: '0.15333333333333332', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "sun 14°46'" },
     { tag: 'text', attrs: { x: '0.08333333333333333', y: '0.32', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "ketu(R) 11°53'" },
-    { tag: 'text', attrs: { x: '0.25', y: '0.98', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "mars 08°19'" },
+    { tag: 'text', attrs: { x: '0.19', y: '0.98', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "mars 08°19'" },
     { tag: 'text', attrs: { x: '0.5', y: '0.8200000000000001', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "mercury(R) 29°13'" },
     { tag: 'text', attrs: { x: '0.5', y: '0.8600000000000001', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "venus 10°02'" },
-    { tag: 'text', attrs: { x: '0.75', y: '0.98', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "moon(Ex) 13°17'" },
+    { tag: 'text', attrs: { x: '0.69', y: '0.98', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "moon(Ex) 13°17'" },
     { tag: 'text', attrs: { x: '0.9166666666666666', y: '0.8200000000000001', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "rahu(R) 11°53'" },
     { tag: 'text', attrs: { x: '0.75', y: '0.15333333333333332', 'text-anchor': 'middle', 'font-size': '0.03' }, text: "saturn(R) 29°14'" },
   ]);

--- a/tests/planet-label-spacing.test.js
+++ b/tests/planet-label-spacing.test.js
@@ -47,16 +47,16 @@ test('planet labels keep clear of sign numbers in every house', () => {
     const bbox = HOUSE_BBOXES[h - 1];
     const signNode = texts.find((t) => t.textContent === String(h));
     assert.ok(signNode, `missing sign label for house ${h}`);
+    const signX = Number(signNode.attributes.x);
     const signY = Number(signNode.attributes.y);
-    const planetYs = texts
-      .filter((t) => t.textContent.startsWith(`p${h}_`))
-      .map((t) => Number(t.attributes.y));
-    const minPlanetY = planetYs.length ? Math.min(...planetYs) : null;
-    const gap =
-      minPlanetY !== null ? +(minPlanetY - signY).toFixed(2) : null;
-    if (gap !== null) {
-      assert.ok(gap >= 0.02, `label overlaps planet in house ${h}`);
-    }
+    const planetNodes = texts.filter((t) => t.textContent.startsWith(`p${h}_`));
+    planetNodes.forEach((p) => {
+      const px = Number(p.attributes.x);
+      const py = Number(p.attributes.y);
+      const dx = Math.abs(px - signX);
+      const dy = Math.abs(py - signY);
+      assert.ok(dy >= 0.02 || dx >= 0.05, `label overlaps planet in house ${h}`);
+    });
     const yPad = +(signY - bbox.minY).toFixed(2);
     assert.ok(yPad >= 0.08, `label touches top border in house ${h}`);
   }

--- a/tests/planet-spacing.test.js
+++ b/tests/planet-spacing.test.js
@@ -26,7 +26,7 @@ class Element {
 
 const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
-test('planets render in distinct rows below sign label', () => {
+test('planets render in distinct rows regardless of house position', () => {
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) signInHouse[h] = h;
   const planets = [
@@ -34,6 +34,9 @@ test('planets render in distinct rows below sign label', () => {
     { name: 'p2', house: 2, deg: 10 },
     { name: 'p3', house: 2, deg: 20 },
     { name: 'p4', house: 2, deg: 30 },
+    { name: 'q1', house: 6, deg: 0 },
+    { name: 'q2', house: 6, deg: 10 },
+    { name: 'q3', house: 6, deg: 20 },
   ];
 
   global.document = doc;
@@ -41,17 +44,18 @@ test('planets render in distinct rows below sign label', () => {
   renderNorthIndian(svg, { ascSign: 1, signInHouse, planets });
   delete global.document;
 
-  const { cx, cy } = HOUSE_CENTROIDS[1]; // house 2
   const texts = svg.children.filter((c) => c.tagName === 'text');
-  const planetYs = texts
-    .filter((t) => Number(t.attributes.x) === cx && t.textContent.startsWith('p'))
-    .map((t) => Number(t.attributes.y));
 
-  assert.strictEqual(planetYs.length, 4);
-  planetYs.forEach((y) => {
-    assert.ok(y >= cy + 0.07, 'planet overlaps sign label');
-  });
-  for (let i = 1; i < planetYs.length; i++) {
-    assert.ok(planetYs[i] - planetYs[i - 1] >= 0.02, 'planet rows overlap');
-  }
+  const checkHouse = (house, prefix) => {
+    const ys = texts
+      .filter((t) => t.textContent.startsWith(prefix))
+      .map((t) => Number(t.attributes.y))
+      .sort((a, b) => b - a);
+    for (let i = 1; i < ys.length; i++) {
+      assert.ok(Math.abs(ys[i] - ys[i - 1]) >= 0.02, 'planet rows overlap');
+    }
+  };
+
+  checkHouse(2, 'p');
+  checkHouse(6, 'q');
 });


### PR DESCRIPTION
## Summary
- prevent planet labels from overlapping sign labels by shifting vertically or laterally
- keep consistent spacing between planets when multiple share a house
- cover label spacing with dedicated rendering tests and update chart snapshots

## Testing
- `npm test tests/planet-label-spacing.test.js tests/planet-spacing.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4ad3030a8832b90e134acd2f538df