### PR TITLE
Refine planet label layout

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -90,26 +90,24 @@ export default function Chart({
     const signBottom = labelY + SIGN_FONT_SIZE / 2;
     const bottomLimit = maxPolyY - PLANET_PAD;
     let px = cx;
-    const baseline = cy + 0.07;
     let py = signBottom + PLANET_GAP;
-    if (py < baseline) py = baseline;
-    let downward = true;
-    if (py > bottomLimit) {
-      py = bottomLimit;
-      downward = false;
+    const baseline = cy + 0.07;
+    const shiftAway = () => {
       const shift = 0.06;
       px =
         signX < cx
           ? Math.min(maxX - PLANET_PAD, cx + shift)
           : Math.max(minX + PLANET_PAD, cx - shift);
+    };
+    if (py > bottomLimit) {
+      py = baseline;
+      shiftAway();
     }
     let step = 0;
     if (planets.length > 1) {
-      const available = downward
-        ? bottomLimit - py
-        : py - (minY + PLANET_PAD);
+      const available = bottomLimit - py;
       step = available > 0 ? Math.min(0.04, available / (planets.length - 1)) : 0;
-      if (!downward) step = -step;
+      if (step < PLANET_GAP) shiftAway();
     }
     return {
       houseNum,

--- a/tests/planet-label-spacing.test.js
+++ b/tests/planet-label-spacing.test.js
@@ -25,15 +25,17 @@ class Element {
 }
 
 const doc = { createElementNS: (ns, tag) => new Element(tag) };
+const MIN_GAP = 0.02;
+const MIN_SHIFT = 0.05;
 
 test('planet labels keep clear of sign numbers in every house', () => {
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) signInHouse[h] = h;
   const planets = [];
-  const counts = [0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5];
+  const counts = [0, 1, 2, 3, 4, 5, 6, 0, 1, 2, 3, 4];
   for (let h = 1; h <= 12; h++) {
     for (let i = 0; i < counts[h - 1]; i++) {
-      planets.push({ name: `p${h}_${i}`, house: h, deg: i * 10 });
+      planets.push({ name: `p${h}_${i}`, house: h, deg: i * 5 });
     }
   }
 
@@ -50,14 +52,23 @@ test('planet labels keep clear of sign numbers in every house', () => {
     const signX = Number(signNode.attributes.x);
     const signY = Number(signNode.attributes.y);
     const planetNodes = texts.filter((t) => t.textContent.startsWith(`p${h}_`));
+    const signBottom = signY + 0.025;
+    const yPad = +(signY - bbox.minY).toFixed(2);
+    assert.ok(yPad >= 0.08, `label touches top border in house ${h}`);
     planetNodes.forEach((p) => {
       const px = Number(p.attributes.x);
       const py = Number(p.attributes.y);
       const dx = Math.abs(px - signX);
-      const dy = Math.abs(py - signY);
-      assert.ok(dy >= 0.02 || dx >= 0.05, `label overlaps planet in house ${h}`);
+      if (py >= signY) {
+        const dy = py - signBottom;
+        assert.ok(dy + 1e-6 >= MIN_GAP || dx >= MIN_SHIFT, `label overlaps planet in house ${h}`);
+      } else {
+        assert.ok(dx >= MIN_SHIFT, `label overlaps planet in house ${h}`);
+      }
     });
-    const yPad = +(signY - bbox.minY).toFixed(2);
-    assert.ok(yPad >= 0.08, `label touches top border in house ${h}`);
+    const ys = planetNodes.map((p) => Number(p.attributes.y)).sort((a, b) => a - b);
+    for (let i = 1; i < ys.length; i++) {
+      assert.ok(ys[i] - ys[i - 1] > 0, `planets not ordered downward in house ${h}`);
+    }
   }
 });


### PR DESCRIPTION
## Summary
- stack planet labels starting just below their sign number and compute spacing to flow downward
- shift planet labels sideways when vertical space runs out to avoid overlapping sign digits
- test to ensure planet labels never collide with sign numbers

## Testing
- `npm test tests/planet-label-spacing.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4c2327828832b82acccffeae6821b