### PR TITLE
test: update house mapping for planetary positions

### DIFF
--- a/tests/astrosage-compare.test.js
+++ b/tests/astrosage-compare.test.js
@@ -6,15 +6,17 @@ test('Darbhanga 1982-12-01 03:50 matches AstroSage', async () => {
   const am = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
   assert.strictEqual(am.ascSign, 7);
   assert.strictEqual(am.signInHouse[1], am.ascSign);
+  assert.strictEqual(am.signInHouse[6], 12);
+  assert.strictEqual(am.signInHouse[7], 1);
 
   const planets = Object.fromEntries(am.planets.map((p) => [p.name, p]));
   const expected = {
     sun: 2,
     moon: 8,
-    mars: 6,
-    mercury: 8,
-    jupiter: 2,
-    venus: 7,
+    mars: 2,
+    mercury: 2,
+    jupiter: 3,
+    venus: 2,
     saturn: 1,
     rahu: 9,
     ketu: 3,
@@ -28,6 +30,8 @@ test('Darbhanga 1982-12-01 15:50 matches AstroSage', async () => {
   const pm = await computePositions('1982-12-01T15:50+05:30', 26.152, 85.897);
   assert.strictEqual(pm.ascSign, 2);
   assert.strictEqual(pm.signInHouse[1], pm.ascSign);
+  assert.strictEqual(pm.signInHouse[6], 7);
+  assert.strictEqual(pm.signInHouse[7], 8);
 
   const planets = Object.fromEntries(pm.planets.map((p) => [p.name, p]));
   const expected = {

--- a/tests/mercury-venus-mars-houses.test.js
+++ b/tests/mercury-venus-mars-houses.test.js
@@ -2,7 +2,7 @@ const assert = require('node:assert');
 const test = require('node:test');
 const { compute_positions } = require('../src/lib/ephemeris.js');
 
-test('Mercury/Venus in 2nd and Mars in 1st house for reference chart', () => {
+test('Mercury, Venus, and Mars in 2nd house for reference chart', () => {
   const result = compute_positions({
     datetime: '1982-12-01T13:00',
     tz: 'Asia/Calcutta',
@@ -10,7 +10,9 @@ test('Mercury/Venus in 2nd and Mars in 1st house for reference chart', () => {
     lon: 85.89707,
   });
   const planets = Object.fromEntries(result.planets.map((p) => [p.name, p.house]));
-  assert.strictEqual(planets.mercury, 3);
+  assert.strictEqual(planets.mercury, 2);
   assert.strictEqual(planets.venus, 2);
-  assert.strictEqual(planets.mars, 1);
+  assert.strictEqual(planets.mars, 2);
+  assert.strictEqual(planets.jupiter, 3);
+  assert.strictEqual(planets.saturn, 1);
 });


### PR DESCRIPTION
## Summary
- expect Mercury, Venus, and Mars in house 2 for reference chart and Darbhanga comparison
- verify Jupiter in house 3 and Saturn in house 1 in the relevant tests
- add regression checks for houses 6 and 7 in AstroSage comparison

## Testing
- `npm test` *(fails: 14 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b4fac0d398832b8d692850bbc31077