### PR TITLE
Add combust indicator to chart summary

### DIFF
--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -234,14 +234,9 @@ export async function computePositions(dtISOWithZone, lat, lon) {
     const lon = sign * 30 + degFloat;
     const retro = p.retro;
     const cDeg = combustDeg[p.name];
-    let combust = false;
-    if (cDeg !== undefined) {
-      // Shortest Sun–planet separation in degrees (0..180)
-      const diff = Math.abs((sunLon - lon + 180) % 360 - 180);
-      if (diff < cDeg) {
-        combust = true;
-      }
-    }
+    const combust =
+      cDeg !== undefined &&
+      Math.abs((sunLon - lon + 180) % 360 - 180) < cDeg;
     const exalt = exaltedSign[p.name];
     const exalted = exalt !== undefined && sign === exalt;
     planets.push({

--- a/src/lib/summary.js
+++ b/src/lib/summary.js
@@ -40,6 +40,7 @@ export function summarizeChart(data) {
       .map((p) => {
         let abbr = PLANET_ABBR[p.name] || p.name.slice(0, 2);
         if (p.retro) abbr += '(R)';
+        if (p.combust) abbr += '(C)';
         const degStr = formatDMS(p);
         return `${abbr} ${degStr}`;
       })

--- a/tests/planet-flags.test.js
+++ b/tests/planet-flags.test.js
@@ -1,6 +1,7 @@
 const assert = require('node:assert');
 const test = require('node:test');
 const { computePositions } = require('../src/lib/astro.js');
+const { summarizeChart } = require('../src/lib/summary.js');
 
 function buildLabel(p) {
   let d = p.deg;
@@ -57,5 +58,12 @@ test('Venus near the Sun shows combust flag', async () => {
   assert.ok(venus.combust, 'Venus should be combust');
   const label = buildLabel({ ...venus, abbr: 'Ve', retrograde: venus.retro });
   assert.ok(label.startsWith('Ve(C)'), 'label should include (C)');
+});
+
+test('combust planets show (C) in chart summary', async () => {
+  const res = await computePositions('2023-08-13T00:00+00:00', 0, 0);
+  const summary = summarizeChart(res);
+  const hasVenusCombust = summary.houses.some((h) => h.includes('Ve(C)'));
+  assert.ok(hasVenusCombust, 'summary should include Ve(C)');
 });
 


### PR DESCRIPTION
## Summary
- compute planetary combustion by measuring Sun separation against per-planet thresholds
- show `(C)` marker for combust planets in chart summaries
- test that Venus displays the combust flag in summary output

## Testing
- `npm test` *(fails: require() cannot be used on an ESM graph with top-level await)*

------
https://chatgpt.com/codex/tasks/task_e_68b526d08668832bbc14191277866ca7