### PR TITLE
Flag combust planets in summary

### DIFF
--- a/src/components/ChartSummary.jsx
+++ b/src/components/ChartSummary.jsx
@@ -36,6 +36,7 @@ export default function ChartSummary({ data }) {
   const planetRows = data.planets.map((p) => {
     let abbr = PLANET_ABBR[p.name] || p.name.slice(0, 2);
     if (p.retro) abbr += '(R)';
+    if (p.combust) abbr += '(C)';
     const signNum = data.signInHouse?.[p.house] || p.sign + 1;
     const signName = SIGN_NAMES[signNum - 1];
     const degStr = formatDMS(p);

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -234,9 +234,12 @@ async function computePositions(dtISOWithZone, lat, lon) {
     const lon = sign * 30 + degFloat;
     const retro = p.retro;
     const cDeg = combustDeg[p.name];
-    const combust =
-      cDeg !== undefined &&
-      Math.abs((sunLon - lon + 180) % 360 - 180) < cDeg;
+    let combust = false;
+    if (cDeg !== undefined) {
+      const diff = (sunLon - lon + 360) % 360;
+      const separation = diff > 180 ? 360 - diff : diff;
+      combust = separation < cDeg;
+    }
     const exalt = exaltedSign[p.name];
     const exalted = exalt !== undefined && sign === exalt;
     planets.push({

--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -55,10 +55,17 @@ function compute_positions({ datetime, tz, lat, lon }, sweInst = swe) {
   const flag =
     sweInst.SEFLG_SWIEPH | sweInst.SEFLG_SPEED | sweInst.SEFLG_SIDEREAL;
   const raw = sweInst.swe_houses_ex(jd, flag, Number(lat), Number(lon), 'W');
-  if (!raw || typeof raw.ascendant === 'undefined' || !Array.isArray(raw.house)) {
+  let houses;
+  if (Array.isArray(raw?.house)) {
+    houses = [null, ...raw.house];
+  } else if (Array.isArray(raw?.houses)) {
+    houses = raw.houses;
+  } else {
     throw new Error('Could not compute houses from swisseph.');
   }
-  const houses = [null, ...raw.house];
+  if (typeof raw.ascendant === 'undefined') {
+    throw new Error('Could not compute houses from swisseph.');
+  }
   const ascendant = raw.ascendant;
   const ascSign = lonToSignDeg(ascendant).sign;
   const start = houses[1];


### PR DESCRIPTION
## Summary
- Improve combustion check using angular separation logic
- Mark combust planets in chart summaries
- Add tests for combust labels and handle alternate house data

## Testing
- `npm test` *(fails: Darbhanga regression and others)*
- `node --test tests/planet-flags.test.js`

------
https://chatgpt.com/codex/tasks/task_e_68b5318dfd54832ba84d7fe055e93455