### PR TITLE
fix import pattern for astro library

### DIFF
--- a/src/calculateChart.js
+++ b/src/calculateChart.js
@@ -2,7 +2,8 @@
 
 import { DateTime } from 'luxon';
 import { getTimezoneName } from './lib/timezone.js';
-import { computePositions } from './lib/astro.js';
+import astro from './lib/astro.js';
+const { computePositions } = astro;
 
 export function longitudeToSign(longitude) {
   longitude = ((longitude % 360) + 360) % 360;

--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
+import astro from '../lib/astro.js';
+const {
   CHART_PATHS,
   HOUSE_POLYGONS,
   HOUSE_BBOXES,
   HOUSE_CENTROIDS,
   getSignLabel,
-} from '../lib/astro.js';
+} = astro;
 
 const PLANET_ABBR = {
   sun: 'Su',

--- a/src/components/ChartSummary.jsx
+++ b/src/components/ChartSummary.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { summarizeChart } from '../lib/summary.js';
-import { SIGN_NAMES } from '../lib/astro.js';
+import astro from '../lib/astro.js';
+const { SIGN_NAMES } = astro;
 
 const PLANET_ABBR = {
   sun: 'Su',

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -407,4 +407,6 @@ module.exports = {
   computePositions,
   renderNorthIndian,
 };
+// Allow default import interop in ESM contexts
+module.exports.default = module.exports;
 

--- a/src/lib/summary.js
+++ b/src/lib/summary.js
@@ -1,4 +1,5 @@
-import { SIGN_NAMES } from './astro.js';
+import astro from './astro.js';
+const { SIGN_NAMES } = astro;
 
 const PLANET_ABBR = {
   sun: 'Su',


### PR DESCRIPTION
## Summary
- use default import for astro library in Chart, ChartSummary, calculateChart, and summary modules
- expose astro library as default export for ESM interop

## Testing
- `npm test` *(fails: 16 tests failed)*
- `npm run build` *(fails: default is not exported by src/lib/astro.js)*

------
https://chatgpt.com/codex/tasks/task_e_68b551c991e8832b96ae2b0cabbf34eb