### PR TITLE
refactor: use namespace import for astro module

### DIFF
--- a/src/calculateChart.js
+++ b/src/calculateChart.js
@@ -2,7 +2,7 @@
 
 import { DateTime } from 'luxon';
 import { getTimezoneName } from './lib/timezone.js';
-import astro from './lib/astro.js';
+import * as astro from './lib/astro.js';
 const { computePositions } = astro;
 
 export function longitudeToSign(longitude) {

--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import astro from '../lib/astro.js';
+import * as astro from '../lib/astro.js';
 const {
   CHART_PATHS,
   HOUSE_POLYGONS,

--- a/src/components/ChartSummary.jsx
+++ b/src/components/ChartSummary.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { summarizeChart } from '../lib/summary.js';
-import astro from '../lib/astro.js';
+import * as astro from '../lib/astro.js';
 const { SIGN_NAMES } = astro;
 
 const PLANET_ABBR = {

--- a/src/lib/summary.js
+++ b/src/lib/summary.js
@@ -1,4 +1,4 @@
-import astro from './astro.js';
+import * as astro from './astro.js';
 const { SIGN_NAMES } = astro;
 
 const PLANET_ABBR = {


### PR DESCRIPTION
## Summary
- refactor Chart components and utilities to import astro via namespace
- ensure consistent namespace import across chart summary and calculations

## Testing
- `npm test` *(fails: 16 failing, 39 passing)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b558c9ec38832b804562c48f6217de