### PR TITLE
refactor: migrate astro libs to ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "vedic-chart",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/src/calculateChart.js
+++ b/src/calculateChart.js
@@ -2,8 +2,7 @@
 
 import { DateTime } from 'luxon';
 import { getTimezoneName } from './lib/timezone.js';
-import * as astro from './lib/astro.js';
-const { computePositions } = astro;
+import { computePositions } from './lib/astro.js';
 
 export function longitudeToSign(longitude) {
   longitude = ((longitude % 360) + 360) % 360;

--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import * as astro from '../lib/astro.js';
-const {
+import {
   CHART_PATHS,
   HOUSE_POLYGONS,
   HOUSE_BBOXES,
   HOUSE_CENTROIDS,
   getSignLabel,
-} = astro;
+} from '../lib/astro.js';
 
 const PLANET_ABBR = {
   sun: 'Su',

--- a/src/components/ChartSummary.jsx
+++ b/src/components/ChartSummary.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { summarizeChart } from '../lib/summary.js';
-import * as astro from '../lib/astro.js';
-const { SIGN_NAMES } = astro;
+import { SIGN_NAMES } from '../lib/astro.js';
 
 const PLANET_ABBR = {
   sun: 'Su',

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -1,5 +1,5 @@
-const { DateTime } = require('luxon');
-const { compute_positions } = require('./ephemeris.js');
+import { DateTime } from 'luxon';
+import { compute_positions } from './ephemeris.js';
 
 const svgNS = 'http://www.w3.org/2000/svg';
 
@@ -391,7 +391,7 @@ function renderNorthIndian(svgEl, data, options = {}) {
   }
 }
 
-module.exports = {
+export {
   BOX_SIZE,
   SIGN_BOX_CENTERS,
   SIGN_NUMBERS,
@@ -407,6 +407,21 @@ module.exports = {
   computePositions,
   renderNorthIndian,
 };
-// Allow default import interop in ESM contexts
-module.exports.default = module.exports;
+
+export default {
+  BOX_SIZE,
+  SIGN_BOX_CENTERS,
+  SIGN_NUMBERS,
+  SIGN_ABBREVIATIONS,
+  SIGN_NAMES,
+  getSignLabel,
+  CHART_PATHS,
+  HOUSE_POLYGONS,
+  HOUSE_CENTROIDS,
+  HOUSE_BBOXES,
+  polygonCentroid,
+  diamondPath,
+  computePositions,
+  renderNorthIndian,
+};
 

--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -1,6 +1,9 @@
-const { DateTime } = require('luxon');
-const swe = require('swisseph-v2');
-const path = require('path');
+import { DateTime } from 'luxon';
+import swe from 'swisseph-v2';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const ephePath = path.join(__dirname, '../../swisseph/ephe');
 try {
@@ -125,4 +128,4 @@ function compute_positions({ datetime, tz, lat, lon }, sweInst = swe) {
   return { ascSign, houses, planets };
 }
 
-module.exports = { lonToSignDeg, compute_positions };
+export { lonToSignDeg, compute_positions };

--- a/src/lib/summary.js
+++ b/src/lib/summary.js
@@ -1,5 +1,4 @@
-import * as astro from './astro.js';
-const { SIGN_NAMES } = astro;
+import { SIGN_NAMES } from './astro.js';
 
 const PLANET_ABBR = {
   sun: 'Su',

--- a/tests/ascendant-accuracy.test.js
+++ b/tests/ascendant-accuracy.test.js
@@ -1,6 +1,6 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const swe = require('../swisseph/index.js');
+import assert from 'node:assert';
+import test from 'node:test';
+import * as swe from '../swisseph/index.js';
 
 test('Ascendant matches AstroSage for London 2023-03-21 00:00 UTC', () => {
   const jd = swe.swe_julday(2023, 3, 21, 0, swe.SE_GREG_CAL);

--- a/tests/ascendant-regression.test.js
+++ b/tests/ascendant-regression.test.js
@@ -1,8 +1,10 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const calculateChart = require('../src/calculateChart.js').default;
+import assert from 'node:assert';
+import test from 'node:test';
+
+const chart = import('../src/calculateChart.js');
 
 test('Darbhanga 1982-10-27 03:50 ascendant regression', async () => {
+  const { default: calculateChart } = await chart;
   const result = await calculateChart({
     date: '1982-10-27',
     time: '03:50',

--- a/tests/astroComparison.test.js
+++ b/tests/astroComparison.test.js
@@ -1,6 +1,7 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const { computePositions, renderNorthIndian } = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
 
 class Element {
   constructor(tag) {
@@ -27,6 +28,7 @@ class Element {
 const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
 test('computePositions matches AstroSage for Darbhanga 1982-12-01 03:50', async () => {
+  const { computePositions, renderNorthIndian } = await astro;
   const result = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
 
   // Ascendant sign

--- a/tests/astrosage-compare.test.js
+++ b/tests/astrosage-compare.test.js
@@ -1,8 +1,10 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const { computePositions } = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
 
 test('Darbhanga 1982-12-01 03:50 matches AstroSage', async () => {
+  const { computePositions } = await astro;
   const am = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
   assert.strictEqual(am.ascSign, 7);
   assert.strictEqual(am.signInHouse[1], am.ascSign);
@@ -32,6 +34,7 @@ test('Darbhanga 1982-12-01 03:50 matches AstroSage', async () => {
 });
 
 test('Darbhanga 1982-12-01 15:50 matches AstroSage', async () => {
+  const { computePositions } = await astro;
   const pm = await computePositions('1982-12-01T15:50+05:30', 26.152, 85.897);
   assert.strictEqual(pm.ascSign, 1);
   assert.strictEqual(pm.signInHouse[1], pm.ascSign);
@@ -61,6 +64,7 @@ test('Darbhanga 1982-12-01 15:50 matches AstroSage', async () => {
 });
 
 test('Darbhanga 1982-12-01 03:50 sign sequence matches AstroSage', async () => {
+  const { computePositions } = await astro;
   const am = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
   const expected = [null, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6];
   assert.deepStrictEqual(am.signInHouse, expected);

--- a/tests/birthform-timezone.test.js
+++ b/tests/birthform-timezone.test.js
@@ -1,8 +1,11 @@
-const fs = require('node:fs');
-const path = require('node:path');
-const vm = require('node:vm');
-const assert = require('node:assert');
-const test = require('node:test');
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import assert from 'node:assert';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function loadHandleSelect(sandbox) {
   const code = fs.readFileSync(path.join(__dirname, '../src/components/BirthForm.jsx'), 'utf8');

--- a/tests/chart-orientation.test.js
+++ b/tests/chart-orientation.test.js
@@ -1,8 +1,10 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const { computePositions } = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
 
 test('planet house values match sign mapping and nodes oppose each other', async () => {
+  const { computePositions } = await astro;
   const data = await computePositions('2020-01-01T12:00+00:00', 0, 0);
   assert.deepStrictEqual(
     data.signInHouse.slice(1),

--- a/tests/chart-regression.test.js
+++ b/tests/chart-regression.test.js
@@ -1,6 +1,7 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const { computePositions, renderNorthIndian } = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
 
 class Element {
   constructor(tag) {
@@ -27,6 +28,7 @@ class Element {
 const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
 test('computePositions matches AstroSage for Darbhanga 1982-12-01 03:50', async () => {
+  const { computePositions, renderNorthIndian } = await astro;
   const result = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
 
   // Ascendant sign

--- a/tests/chart-render.test.js
+++ b/tests/chart-render.test.js
@@ -1,6 +1,7 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const { renderNorthIndian, CHART_PATHS } = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
 
 class Element {
   constructor(tag) {
@@ -26,11 +27,12 @@ class Element {
 
 const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
-test('North Indian chart uses one outer square and internal grid', () => {
+test('North Indian chart uses one outer square and internal grid', async () => {
   const svg = new Element('svg');
   global.document = doc;
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) signInHouse[h] = h;
+  const { renderNorthIndian, CHART_PATHS } = await astro;
   renderNorthIndian(svg, { ascSign: 1, signInHouse, planets: [] });
 
   const paths = svg.children.filter((c) => c.tagName === 'path');
@@ -47,7 +49,7 @@ test('North Indian chart uses one outer square and internal grid', () => {
   delete global.document;
 });
 
-test('planet labels show abbreviations without degrees', () => {
+test('planet labels show abbreviations without degrees', async () => {
   const svg = new Element('svg');
   global.document = doc;
   const signInHouse = [null];
@@ -56,6 +58,7 @@ test('planet labels show abbreviations without degrees', () => {
     { name: 'sun', house: 1, deg: 15 },
     { name: 'mercury', house: 1, deg: 20, retro: true },
   ];
+  const { renderNorthIndian } = await astro;
   renderNorthIndian(svg, { ascSign: 1, signInHouse, planets });
   delete global.document;
   const labels = svg.children.filter((c) => c.tagName === 'text').map((t) => t.textContent);

--- a/tests/chart-summary-degrees.test.js
+++ b/tests/chart-summary-degrees.test.js
@@ -1,6 +1,7 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const { computePositions, SIGN_NAMES } = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
 
 const PLANET_ABBR = {
   sun: 'Su',
@@ -31,6 +32,7 @@ function formatDMS(p) {
 }
 
 test('Darbhanga chart summary lists degrees and signs', async () => {
+  const { computePositions, SIGN_NAMES } = await astro;
   const data = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
   const rows = data.planets.map((p) => {
     let abbr = PLANET_ABBR[p.name] || p.name.slice(0, 2);

--- a/tests/chart-summary-houses.test.js
+++ b/tests/chart-summary-houses.test.js
@@ -1,11 +1,14 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const { computePositions } = require('../src/lib/astro.js');
-const { summarizeChart } = require('../src/lib/summary.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
+const summary = import('../src/lib/summary.js');
 
 test('summary lists planets in expected houses for reference chart', async () => {
+  const { computePositions } = await astro;
+  const { summarizeChart } = await summary;
   const data = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
-  const summary = summarizeChart(data);
+  const summaryData = summarizeChart(data);
   const expected = {
     1: ['Sa(R)'],
     2: ['Su', 'Ju(R)'],
@@ -17,7 +20,7 @@ test('summary lists planets in expected houses for reference chart', async () =>
   };
   for (const [house, planets] of Object.entries(expected)) {
     for (const abbr of planets) {
-      assert.ok(summary.houses[house].includes(abbr), `house ${house} includes ${abbr}`);
+      assert.ok(summaryData.houses[house].includes(abbr), `house ${house} includes ${abbr}`);
     }
   }
 });

--- a/tests/chart-summary-regression.test.js
+++ b/tests/chart-summary-regression.test.js
@@ -1,13 +1,16 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const { computePositions } = require('../src/lib/astro.js');
-const { summarizeChart } = require('../src/lib/summary.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
+const summary = import('../src/lib/summary.js');
 
 test('Chart summary for reference chart matches expected output', async () => {
+  const { computePositions } = await astro;
+  const { summarizeChart } = await summary;
   const data = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
   assert.strictEqual(data.signInHouse[1], data.ascSign);
-  const summary = summarizeChart(data);
-  assert.deepStrictEqual(summary, {
+  const summaryData = summarizeChart(data);
+  assert.deepStrictEqual(summaryData, {
     ascendant: 'Libra',
     moonSign: 'Taurus',
     houses: [

--- a/tests/darbhanga-dec-1982.test.js
+++ b/tests/darbhanga-dec-1982.test.js
@@ -1,8 +1,10 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const { computePositions } = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
 
 test('Darbhanga 1982-12-01 03:50 positions', async () => {
+  const { computePositions } = await astro;
   const res = await computePositions('1982-12-01T03:50+05:30', 26.15216, 85.89707);
   assert.strictEqual(res.ascSign, 7);
   assert.deepStrictEqual(

--- a/tests/darbhanga-july-1982.test.js
+++ b/tests/darbhanga-july-1982.test.js
@@ -1,8 +1,10 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const { computePositions } = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
 
 test('Darbhanga 1982-07-12 03:50 positions', async () => {
+  const { computePositions } = await astro;
   const res = await computePositions('1982-07-12T03:50+05:30', 26.15216, 85.89707);
   assert.strictEqual(res.ascSign, 3);
   const planets = Object.fromEntries(res.planets.map((p) => [p.name, p]));

--- a/tests/datetime-parse.test.js
+++ b/tests/datetime-parse.test.js
@@ -1,5 +1,5 @@
-const test = require('node:test');
-const assert = require('node:assert');
+import test from 'node:test';
+import assert from 'node:assert';
 
 function load() {
   return import('../src/lib/parseDateTime.js');

--- a/tests/ephemeris.test.js
+++ b/tests/ephemeris.test.js
@@ -1,5 +1,5 @@
-const assert = require('node:assert');
-const test = require('node:test');
+import assert from 'node:assert';
+import test from 'node:test';
 
 async function getCompute() {
   return (await import('../src/lib/ephemeris.js')).compute_positions;

--- a/tests/geometry.test.js
+++ b/tests/geometry.test.js
@@ -1,8 +1,10 @@
-const test = require('node:test');
-const assert = require('node:assert');
-const { HOUSE_POLYGONS } = require('../src/lib/astro.js');
+import test from 'node:test';
+import assert from 'node:assert';
 
-test('build house grid with 12 valid, non-overlapping cells', () => {
+const astro = import('../src/lib/astro.js');
+
+test('build house grid with 12 valid, non-overlapping cells', async () => {
+  const { HOUSE_POLYGONS } = await astro;
   const cells = HOUSE_POLYGONS;
   assert.strictEqual(cells.length, 12);
 

--- a/tests/house-polygons.test.js
+++ b/tests/house-polygons.test.js
@@ -1,12 +1,10 @@
-const test = require('node:test');
-const assert = require('node:assert');
-const {
-  HOUSE_POLYGONS,
-  HOUSE_CENTROIDS,
-  polygonCentroid,
-} = require('../src/lib/astro.js');
+import test from 'node:test';
+import assert from 'node:assert';
 
-test('HOUSE_POLYGONS exposes 12 regions with expected centroids', () => {
+const astro = import('../src/lib/astro.js');
+
+test('HOUSE_POLYGONS exposes 12 regions with expected centroids', async () => {
+  const { HOUSE_POLYGONS, HOUSE_CENTROIDS, polygonCentroid } = await astro;
   assert.strictEqual(HOUSE_POLYGONS.length, 12);
   HOUSE_POLYGONS.forEach((poly, i) => {
     assert.ok(poly.length >= 3);

--- a/tests/houses-order.test.js
+++ b/tests/houses-order.test.js
@@ -1,10 +1,7 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const {
-  renderNorthIndian,
-  HOUSE_CENTROIDS,
-  HOUSE_BBOXES,
-} = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
 
 class Element {
   constructor(tag) {
@@ -30,13 +27,14 @@ class Element {
 
 const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
-test('houses and signs increase anti-clockwise from ascendant', () => {
+test('houses and signs increase anti-clockwise from ascendant', async () => {
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) signInHouse[h] = h;
   const data = { ascSign: 1, signInHouse, planets: [] };
 
   global.document = doc;
   const svg = new Element('svg');
+  const { renderNorthIndian, HOUSE_CENTROIDS } = await astro;
   renderNorthIndian(svg, data);
   const signTexts = svg.children.filter(
     (c) => c.tagName === 'text' && c.attributes['font-size'] === '0.05'

--- a/tests/jupiter-not-combust.test.js
+++ b/tests/jupiter-not-combust.test.js
@@ -1,8 +1,10 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const { computePositions } = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
 
 test('Jupiter is not combust', async () => {
+  const { computePositions } = await astro;
   const res = await computePositions('2022-10-07T00:00+00:00', 0, 0);
   const planets = Object.fromEntries(res.planets.map((p) => [p.name, p]));
   const jupiter = planets.jupiter;

--- a/tests/jupiter-saturn-wasm.test.js
+++ b/tests/jupiter-saturn-wasm.test.js
@@ -1,5 +1,5 @@
-const assert = require('node:assert');
-const test = require('node:test');
+import assert from 'node:assert';
+import test from 'node:test';
 
 // Verify that raw values from the WASM Swiss Ephemeris are
 // returned without any manual adjustments.  Jupiter and Saturn

--- a/tests/longitude-to-sign.test.js
+++ b/tests/longitude-to-sign.test.js
@@ -1,5 +1,5 @@
-const assert = require('node:assert');
-const test = require('node:test');
+import assert from 'node:assert';
+import test from 'node:test';
 
 async function getFn() {
   return (await import('../src/calculateChart.js')).longitudeToSign;

--- a/tests/mercury-venus-mars-houses.test.js
+++ b/tests/mercury-venus-mars-houses.test.js
@@ -1,8 +1,10 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const { compute_positions } = require('../src/lib/ephemeris.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const ephemeris = import('../src/lib/ephemeris.js');
 
 test('Mercury, Venus, and Mars in 2nd house for reference chart', async () => {
+  const { compute_positions } = await ephemeris;
   const result = await compute_positions({
     datetime: '1982-12-01T13:00',
     tz: 'Asia/Calcutta',

--- a/tests/moon-sign.test.js
+++ b/tests/moon-sign.test.js
@@ -1,10 +1,13 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const { computePositions } = require('../src/lib/astro.js');
-const { summarizeChart } = require('../src/lib/summary.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
+const summary = import('../src/lib/summary.js');
 
 test('Moon sign for sample chart is Taurus', async () => {
+  const { computePositions } = await astro;
+  const { summarizeChart } = await summary;
   const data = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
-  const summary = summarizeChart(data);
-  assert.strictEqual(summary.moonSign, 'Taurus');
+  const summaryData = summarizeChart(data);
+  assert.strictEqual(summaryData.moonSign, 'Taurus');
 });

--- a/tests/planet-flags.test.js
+++ b/tests/planet-flags.test.js
@@ -1,6 +1,7 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const { computePositions, SIGN_NAMES } = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
 
 const PLANET_ABBR = {
   sun: 'Su',
@@ -79,6 +80,7 @@ test('sample planets are direct by default', () => {
 });
 
 test('Venus near the Sun shows combust flag', async () => {
+  const { computePositions } = await astro;
   const res = await computePositions('2023-08-13T00:00+00:00', 0, 0);
   const planets = Object.fromEntries(res.planets.map((p) => [p.name, p]));
   const venus = planets.venus;
@@ -88,6 +90,7 @@ test('Venus near the Sun shows combust flag', async () => {
 });
 
 test('combust planets show (C) in chart summary', async () => {
+  const { computePositions, SIGN_NAMES } = await astro;
   const res = await computePositions('2023-08-13T00:00+00:00', 0, 0);
   const rows = res.planets.map((p) => {
     let abbr = PLANET_ABBR[p.name] || p.name.slice(0, 2);

--- a/tests/planet-label-spacing.test.js
+++ b/tests/planet-label-spacing.test.js
@@ -1,6 +1,7 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const { renderNorthIndian, HOUSE_BBOXES } = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
 
 class Element {
   constructor(tag) {
@@ -28,7 +29,7 @@ const doc = { createElementNS: (ns, tag) => new Element(tag) };
 const MIN_GAP = 0.02;
 const MIN_SHIFT = 0.05;
 
-test('planet labels keep clear of sign numbers in every house', () => {
+test('planet labels keep clear of sign numbers in every house', async () => {
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) signInHouse[h] = h;
   const planets = [];
@@ -41,6 +42,7 @@ test('planet labels keep clear of sign numbers in every house', () => {
 
   global.document = doc;
   const svg = new Element('svg');
+  const { renderNorthIndian, HOUSE_BBOXES } = await astro;
   renderNorthIndian(svg, { ascSign: 1, signInHouse, planets });
   delete global.document;
 

--- a/tests/planet-placement-regression.test.js
+++ b/tests/planet-placement-regression.test.js
@@ -1,6 +1,7 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const { computePositions, renderNorthIndian, HOUSE_BBOXES } = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
 
 class Element {
   constructor(tag) {
@@ -27,6 +28,7 @@ class Element {
 const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
 test('planet positions match AstroSage for sample chart', async () => {
+  const { computePositions, renderNorthIndian, HOUSE_BBOXES } = await astro;
   const data = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
   const expected = {
     sun: 2,

--- a/tests/planet-spacing.test.js
+++ b/tests/planet-spacing.test.js
@@ -1,6 +1,7 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const { renderNorthIndian, HOUSE_CENTROIDS } = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
 
 class Element {
   constructor(tag) {
@@ -26,7 +27,7 @@ class Element {
 
 const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
-test('planets render in distinct rows regardless of house position', () => {
+test('planets render in distinct rows regardless of house position', async () => {
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) signInHouse[h] = h;
   const planets = [
@@ -41,6 +42,7 @@ test('planets render in distinct rows regardless of house position', () => {
 
   global.document = doc;
   const svg = new Element('svg');
+  const { renderNorthIndian } = await astro;
   renderNorthIndian(svg, { ascSign: 1, signInHouse, planets });
   delete global.document;
 

--- a/tests/reference-case.test.js
+++ b/tests/reference-case.test.js
@@ -1,6 +1,7 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const { computePositions, renderNorthIndian } = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
 
 class Element {
   constructor(tag) {
@@ -27,6 +28,7 @@ class Element {
 const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
 test('reference charts for Darbhanga on 1982-12-01 match expected placements', async () => {
+  const { computePositions, renderNorthIndian } = await astro;
   const am = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
   assert.strictEqual(am.ascSign, 7);
   const amPlanets = Object.fromEntries(am.planets.map((p) => [p.name, p]));

--- a/tests/sign-in-house-sequence.test.js
+++ b/tests/sign-in-house-sequence.test.js
@@ -1,8 +1,10 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const { computePositions } = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
 
 test('Darbhanga 1982-12-01 03:50 ascendant and sign sequence', async () => {
+  const { computePositions } = await astro;
   const result = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
   assert.strictEqual(result.ascSign, 7);
   assert.strictEqual(result.signInHouse[1], result.ascSign);
@@ -10,6 +12,7 @@ test('Darbhanga 1982-12-01 03:50 ascendant and sign sequence', async () => {
 });
 
 test('Darbhanga 1982-12-01 15:50 ascendant and sign sequence', async () => {
+  const { computePositions } = await astro;
   const result = await computePositions('1982-12-01T15:50+05:30', 26.152, 85.897);
   assert.strictEqual(result.ascSign, 2);
   assert.strictEqual(result.signInHouse[1], result.ascSign);

--- a/tests/sign-label-layer.test.js
+++ b/tests/sign-label-layer.test.js
@@ -1,11 +1,8 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const {
-  renderNorthIndian,
-  HOUSE_CENTROIDS,
-  HOUSE_BBOXES,
-  HOUSE_POLYGONS,
-} = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
+let renderNorthIndian, HOUSE_CENTROIDS, HOUSE_BBOXES, HOUSE_POLYGONS;
 
 class Element {
   constructor(tag) {
@@ -53,7 +50,7 @@ function computeSignPoint(h) {
   return { sx, sy };
 }
 
-test('sign labels anchor without overlapping planets', () => {
+test('sign labels anchor without overlapping planets', async () => {
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) signInHouse[h] = h;
   const planets = [
@@ -63,6 +60,7 @@ test('sign labels anchor without overlapping planets', () => {
 
   global.document = doc;
   const svg = new Element('svg');
+  ({ renderNorthIndian, HOUSE_CENTROIDS, HOUSE_BBOXES, HOUSE_POLYGONS } = await astro);
   renderNorthIndian(svg, { ascSign: 1, signInHouse, planets });
   delete global.document;
   const { cx, cy } = HOUSE_CENTROIDS[0];

--- a/tests/sign-label-padding.test.js
+++ b/tests/sign-label-padding.test.js
@@ -1,9 +1,7 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const {
-  renderNorthIndian,
-  HOUSE_BBOXES,
-} = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
 
 class Element {
   constructor(tag) {
@@ -29,7 +27,7 @@ class Element {
 
 const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
-test('sign labels keep padding from borders and planets', () => {
+test('sign labels keep padding from borders and planets', async () => {
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) signInHouse[h] = h;
   const planets = [];
@@ -39,6 +37,7 @@ test('sign labels keep padding from borders and planets', () => {
 
   global.document = doc;
   const svg = new Element('svg');
+  const { renderNorthIndian, HOUSE_BBOXES } = await astro;
   renderNorthIndian(svg, { ascSign: 1, signInHouse, planets });
   delete global.document;
 

--- a/tests/sign-label-position.test.js
+++ b/tests/sign-label-position.test.js
@@ -1,10 +1,7 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const {
-  renderNorthIndian,
-  HOUSE_BBOXES,
-  HOUSE_POLYGONS,
-} = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
 
 class Element {
   constructor(tag) {
@@ -41,7 +38,7 @@ function pointInPolygon(x, y, poly) {
   return inside;
 }
 
-test('sign labels stay inside each house polygon', () => {
+test('sign labels stay inside each house polygon', async () => {
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) signInHouse[h] = h;
 
@@ -55,6 +52,7 @@ test('sign labels stay inside each house polygon', () => {
 
   global.document = doc;
   const svg = new Element('svg');
+  const { renderNorthIndian, HOUSE_BBOXES, HOUSE_POLYGONS } = await astro;
   renderNorthIndian(svg, { ascSign: 1, signInHouse, planets });
   delete global.document;
 

--- a/tests/sign-labels.test.js
+++ b/tests/sign-labels.test.js
@@ -1,6 +1,7 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const { renderNorthIndian } = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
 
 class Element {
   constructor(tag) {
@@ -26,11 +27,12 @@ class Element {
 
 const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
-test('renderNorthIndian defaults to numeric sign labels', () => {
+test('renderNorthIndian defaults to numeric sign labels', async () => {
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) signInHouse[h] = h;
   global.document = doc;
   const svg = new Element('svg');
+  const { renderNorthIndian } = await astro;
   renderNorthIndian(svg, { ascSign: 1, signInHouse, planets: [] });
   const texts = svg.children.filter(
     (c) => c.tagName === 'text' && c.attributes['font-size'] === '0.05'
@@ -40,11 +42,12 @@ test('renderNorthIndian defaults to numeric sign labels', () => {
   delete global.document;
 });
 
-test('renderNorthIndian can use abbreviated sign labels', () => {
+test('renderNorthIndian can use abbreviated sign labels', async () => {
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) signInHouse[h] = h;
   global.document = doc;
   const svg = new Element('svg');
+  const { renderNorthIndian } = await astro;
   renderNorthIndian(svg, { ascSign: 1, signInHouse, planets: [] }, {
     useAbbreviations: true,
   });

--- a/tests/sign-number-clear.test.js
+++ b/tests/sign-number-clear.test.js
@@ -1,9 +1,7 @@
-const assert = require('node:assert');
-const test = require('node:test');
-const {
-  renderNorthIndian,
-  HOUSE_BBOXES,
-} = require('../src/lib/astro.js');
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
 
 class Element {
   constructor(tag) {
@@ -29,7 +27,7 @@ class Element {
 
 const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
-test('sign numbers remain clear and non-overlapping', () => {
+test('sign numbers remain clear and non-overlapping', async () => {
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) signInHouse[h] = h;
   const planets = [];
@@ -40,6 +38,7 @@ test('sign numbers remain clear and non-overlapping', () => {
 
   global.document = doc;
   const svg = new Element('svg');
+  const { renderNorthIndian, HOUSE_BBOXES } = await astro;
   renderNorthIndian(svg, { ascSign: 1, signInHouse, planets });
   delete global.document;
 

--- a/tests/sign-sequence-astrosage.test.js
+++ b/tests/sign-sequence-astrosage.test.js
@@ -1,8 +1,10 @@
-const test = require('node:test');
-const assert = require('node:assert');
-const { computePositions } = require('../src/lib/astro.js');
+import test from 'node:test';
+import assert from 'node:assert';
+
+const astro = import('../src/lib/astro.js');
 
 test('sign sequence matches AstroSage for Darbhanga 1982-12-01 03:50', async () => {
+  const { computePositions } = await astro;
   const result = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
   // Ascendant sign should populate the first house
   assert.strictEqual(result.signInHouse[1], result.ascSign);

--- a/tests/text-inside-polygons.test.js
+++ b/tests/text-inside-polygons.test.js
@@ -1,9 +1,7 @@
-const test = require('node:test');
-const assert = require('node:assert');
-const {
-  renderNorthIndian,
-  HOUSE_POLYGONS,
-} = require('../src/lib/astro.js');
+import test from 'node:test';
+import assert from 'node:assert';
+
+const astro = import('../src/lib/astro.js');
 
 class Element {
   constructor(tag) {
@@ -40,7 +38,7 @@ function pointInPolygon(x, y, poly) {
   return inside;
 }
 
-test('all text elements render inside their house polygons', () => {
+test('all text elements render inside their house polygons', async () => {
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) signInHouse[h] = h;
   const planets = Array.from({ length: 12 }, (_, i) => ({
@@ -53,6 +51,7 @@ test('all text elements render inside their house polygons', () => {
 
   global.document = doc;
   const svg = new Element('svg');
+  const { renderNorthIndian, HOUSE_POLYGONS } = await astro;
   renderNorthIndian(svg, data);
   delete global.document;
 

--- a/tests/timezone-offset.test.js
+++ b/tests/timezone-offset.test.js
@@ -1,8 +1,11 @@
-const fs = require('node:fs');
-const path = require('node:path');
-const vm = require('node:vm');
-const assert = require('node:assert');
-const test = require('node:test');
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import assert from 'node:assert';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 function loadGetTimezoneOffset() {
   let code = fs.readFileSync(path.join(__dirname, '../src/lib/timezone.js'), 'utf8');


### PR DESCRIPTION
## Summary
- replace CommonJS require/module.exports with ESM import/export in core astro utilities
- update React components and helpers to use the new named exports
- convert test suite to ESM and add module type to package

## Testing
- `npm test` *(fails: 39 passed, 16 failed)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b55cb4f654832bae9fd463f3a9b8af