### PR TITLE
Refactor planet label abbreviation logic

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -43,10 +43,14 @@ export default function Chart({
   data.planets.forEach((p) => {
     const houseIdx = p.house;
     if (houseIdx === undefined) return;
-    let abbr = PLANET_ABBR[p.name.toLowerCase()] || p.name.slice(0, 2);
-    if (p.retro) abbr += '(R)';
-    if (p.combust) abbr += '(C)';
-    if (p.exalted) abbr += '(Ex)';
+
+    const baseAbbr = PLANET_ABBR[p.name.toLowerCase()] || p.name.slice(0, 2);
+    const flags = [];
+    if (p.retro) flags.push('(R)');
+    if (p.combust) flags.push('(C)');
+    if (p.exalted) flags.push('(Ex)');
+    const abbr = baseAbbr + flags.join('');
+
     planetByHouse[houseIdx] = planetByHouse[houseIdx] || [];
     planetByHouse[houseIdx].push(abbr);
   });


### PR DESCRIPTION
## Summary
- Build planet labels from base abbreviations plus retrograde, combust, and exalted flags only

## Testing
- `npm test` *(fails: mercury house assertions, sign sequence mismatch, text rendering)*

------
https://chatgpt.com/codex/tasks/task_e_68b5948e4e54832b891a96e8e235db82