### PR TITLE
test: add Jupiter direct house test

### DIFF
--- a/tests/astrosage-compare.test.js
+++ b/tests/astrosage-compare.test.js
@@ -69,3 +69,13 @@ test('Darbhanga 1982-12-01 03:50 sign sequence matches AstroSage', async () => {
   const expected = [null, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6, 7, 8];
   assert.deepStrictEqual(am.signInHouse, expected);
 });
+
+test('Darbhanga 1982-12-01 03:50: Jupiter, Mercury, Venus in house 2; Jupiter direct', async () => {
+  const { computePositions } = await astro;
+  const res = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
+  const planets = Object.fromEntries(res.planets.map((p) => [p.name, p]));
+  for (const name of ['jupiter', 'mercury', 'venus']) {
+    assert.strictEqual(planets[name].house, 2, `${name} house`);
+  }
+  assert.ok(!planets.jupiter.retro, 'Jupiter should be direct');
+});


### PR DESCRIPTION
## Summary
- add regression test for Jupiter, Mercury, Venus second-house placement and direct Jupiter

## Testing
- `npm test` *(fails: 18 failing tests including new test)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a3d23b70832ba7c36e62e1206eec