### PR TITLE
refactor: simplify planet labels

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -49,10 +49,12 @@ export default function Chart({
     if (p.retro) flags.push('(R)');
     if (p.combust) flags.push('(C)');
     if (p.exalted) flags.push('(Ex)');
-    const abbr = baseAbbr + flags.join('');
+    // Store only the abbreviation and any flags; degree information is
+    // intentionally omitted to keep the chart labels concise.
+    const label = baseAbbr + flags.join('');
 
     planetByHouse[houseIdx] = planetByHouse[houseIdx] || [];
-    planetByHouse[houseIdx].push(abbr);
+    planetByHouse[houseIdx].push(label);
   });
 
   const SIGN_PAD_X = 0.04;


### PR DESCRIPTION
## Summary
- ensure chart uses planet abbreviations with flags only and omits degree text

## Testing
- `node --test tests/chart-render.test.js`
- `node --test tests/chart-summary-degrees.test.js` *(fails: Expected values to be strictly deep-equal)*

------
https://chatgpt.com/codex/tasks/task_e_68b5aa868340832b8a6a43b558aa186c