### PR TITLE
Fix ephemeris UTC time and add Darbhanga regression test

### DIFF
--- a/tests/darbhanga1982.test.js
+++ b/tests/darbhanga1982.test.js
@@ -1,0 +1,32 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+const eph = import('../src/lib/ephemeris.js');
+
+test('Darbhanga 1982 chart regression', async () => {
+  const { compute_positions } = await eph;
+  const res = await compute_positions({
+    datetime: '1982-12-01T03:50',
+    tz: 'Asia/Calcutta',
+    lat: 26.15216,
+    lon: 85.89707,
+  });
+
+  assert.strictEqual(res.ascendant.sign, 7);
+  assert.strictEqual(res.ascendant.deg, 12);
+  assert.strictEqual(res.ascendant.min, 16);
+
+  const houses = Object.fromEntries(res.planets.map((p) => [p.name, p.house]));
+  assert.deepStrictEqual(houses, {
+    sun: 2,
+    moon: 8,
+    mercury: 2,
+    venus: 2,
+    mars: 3,
+    jupiter: 2,
+    saturn: 1,
+    rahu: 9,
+    ketu: 3,
+  });
+});
+


### PR DESCRIPTION
## Summary
- ensure ephemeris path resolves correctly and compute houses from returned cusps
- adjust house calculation to use ascendant longitude
- add regression test for Darbhanga 1982 chart

## Testing
- `npm test` *(fails: sun house: 1 !== 2)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b51e7734832b90a85dc483aca805