### PR TITLE
Limit chart abbreviations to flags and keep summary degrees

### DIFF
--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -45,13 +45,16 @@ export default function Chart({
     if (houseIdx === undefined) return;
 
     const baseAbbr = PLANET_ABBR[p.name.toLowerCase()] || p.name.slice(0, 2);
-    const flags = [];
-    if (p.retro) flags.push('(R)');
-    if (p.combust) flags.push('(C)');
-    if (p.exalted) flags.push('(Ex)');
+    const flags = [
+      p.retro && '(R)',
+      p.combust && '(C)',
+      p.exalted && '(Ex)',
+    ]
+      .filter(Boolean)
+      .join('');
     // Store only the abbreviation and any flags; degree information is
     // intentionally omitted to keep the chart labels concise.
-    const label = baseAbbr + flags.join('');
+    const label = baseAbbr + flags;
 
     planetByHouse[houseIdx] = planetByHouse[houseIdx] || [];
     planetByHouse[houseIdx].push(label);

--- a/src/components/ChartSummary.jsx
+++ b/src/components/ChartSummary.jsx
@@ -38,6 +38,7 @@ export default function ChartSummary({ data }) {
     const flags = [];
     if (p.retro) flags.push('(R)');
     if (p.combust) flags.push('(C)');
+    if (p.exalted) flags.push('(Ex)');
     if (flags.length > 0) {
       abbr += flags.join('');
     }
@@ -78,6 +79,9 @@ ChartSummary.propTypes = {
         deg: PropTypes.number,
         min: PropTypes.number,
         sec: PropTypes.number,
+        retro: PropTypes.bool,
+        combust: PropTypes.bool,
+        exalted: PropTypes.bool,
       })
     ).isRequired,
   }).isRequired,

--- a/tests/chart-summary-degrees.test.js
+++ b/tests/chart-summary-degrees.test.js
@@ -37,6 +37,8 @@ test('Darbhanga chart summary lists degrees and signs', async () => {
   const rows = data.planets.map((p) => {
     let abbr = PLANET_ABBR[p.name] || p.name.slice(0, 2);
     if (p.retro) abbr += '(R)';
+    if (p.combust) abbr += '(C)';
+    if (p.exalted) abbr += '(Ex)';
     const signNum = data.signInHouse?.[p.house] || p.sign + 1;
     const signName = SIGN_NAMES[signNum - 1];
     const degStr = formatDMS(p);
@@ -44,7 +46,7 @@ test('Darbhanga chart summary lists degrees and signs', async () => {
   });
   assert.deepStrictEqual(rows, [
     'Su Scorpio 14°46′28″',
-    'Mo Taurus 13°16′59″',
+    'Mo(Ex) Taurus 13°16′59″',
     'Me(R) Aries 29°13′15″',
     'Ve Aries 10°02′30″',
     'Ma Pisces 8°19′13″',


### PR DESCRIPTION
## Summary
- Ensure `Chart` planet labels show only the planet abbreviation plus `(R)`, `(C)` or `(Ex)` flags
- Keep `ChartSummary` rows with full degree/minute/second values and support exalted flag
- Update degrees summary test to expect exalted flag and new label logic

## Testing
- `SE_EPHE_PATH=./swisseph/ephe npm test` *(fails: 20 failing subtests)*

------
https://chatgpt.com/codex/tasks/task_e_68b639ed8fb8832bb6ec7424d8594d89