### PR TITLE
derive house from cusps

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -37,6 +37,19 @@ function lonToSignDeg(longitude) {
   return { sign, deg, min, sec };
 }
 
+function houseOfLongitude(lon, cusps) {
+  if (!Array.isArray(cusps) || cusps.length < 13) return 1;
+  for (let i = 1; i <= 12; i++) {
+    const start = cusps[i];
+    let end = i === 12 ? cusps[1] + 360 : cusps[i + 1];
+    if (end < start) end += 360;
+    let l = lon;
+    if (l < start) l += 360;
+    if (l >= start && l < end) return i;
+  }
+  return 1;
+}
+
 function toUTC({ datetime, zone }) {
   const dt = DateTime.fromISO(datetime, { zone }).toUTC();
   return dt.toJSDate();
@@ -108,8 +121,7 @@ async function compute_positions({ datetime, tz, lat, lon }, sweInst = swe) {
       lon,
       speed: data.longitudeSpeed,
       retro,
-      house:
-        Math.floor(((lon - raw.ascendant + 360) % 360) / 30) + 1,
+      house: houseOfLongitude(lon, houses),
     });
   }
   const ketuLon = (rahuData.longitude + 180) % 360;
@@ -123,7 +135,7 @@ async function compute_positions({ datetime, tz, lat, lon }, sweInst = swe) {
     lon: ketuLon,
     speed: rahuData.longitudeSpeed,
     retro: rahuData.longitudeSpeed < 0,
-    house: Math.floor(((ketuLon - raw.ascendant + 360) % 360) / 30) + 1,
+    house: houseOfLongitude(ketuLon, houses),
   });
 
   return {

--- a/tests/darbhanga-dec-1982.test.js
+++ b/tests/darbhanga-dec-1982.test.js
@@ -60,4 +60,14 @@ test('Darbhanga 1982-12-01 03:50 positions', async () => {
     assert.strictEqual(p.min, exp.min, `${name} min`);
     assert.strictEqual(p.sec, exp.sec, `${name} sec`);
   }
+
+  const secondHouse = ['sun', 'mercury', 'venus', 'jupiter'];
+  for (const name of secondHouse) {
+    const p = planets[name];
+    const exp = expectedDMS[name];
+    assert.strictEqual(p.house, 2, `${name} 2nd house`);
+    assert.strictEqual(p.deg, exp.deg, `${name} deg`);
+    assert.strictEqual(p.min, exp.min, `${name} min`);
+    assert.strictEqual(p.sec, exp.sec, `${name} sec`);
+  }
 });


### PR DESCRIPTION
## Summary
- add `houseOfLongitude` helper to map longitudes to houses using cusps
- use helper when computing planet houses
- expand Darbhanga 1982 regression test for planets in 2nd house

## Testing
- `npm test` *(fails: mercury house 1 !== 2)*

------
https://chatgpt.com/codex/tasks/task_e_68b71b718d74832bbdacaa5ea54456b1