### PR TITLE
Use planetary sign for chart summary

### DIFF
--- a/src/components/ChartSummary.jsx
+++ b/src/components/ChartSummary.jsx
@@ -41,7 +41,7 @@ export default function ChartSummary({ data }) {
     if (p.exalted) flags.push('(Ex)');
     // Ensure combust planets render with a (C) marker alongside other flags.
     abbr += flags.join('');
-    const signNum = data.signInHouse?.[p.house] || p.sign + 1;
+    const signNum = p.sign + 1;
     const signName = SIGN_NAMES[signNum - 1];
     const degStr = formatDMS(p);
     return { abbr, signName, degStr };
@@ -69,7 +69,6 @@ export default function ChartSummary({ data }) {
 ChartSummary.propTypes = {
   data: PropTypes.shape({
     ascSign: PropTypes.number.isRequired,
-    signInHouse: PropTypes.arrayOf(PropTypes.number).isRequired,
     planets: PropTypes.arrayOf(
       PropTypes.shape({
         name: PropTypes.string.isRequired,

--- a/tests/chart-summary-degrees.test.js
+++ b/tests/chart-summary-degrees.test.js
@@ -39,7 +39,7 @@ test('Darbhanga chart summary lists degrees and signs', async () => {
     if (p.retro) abbr += '(R)';
     if (p.combust) abbr += '(C)';
     if (p.exalted) abbr += '(Ex)';
-    const signNum = data.signInHouse?.[p.house] || p.sign + 1;
+    const signNum = p.sign + 1;
     const signName = SIGN_NAMES[signNum - 1];
     const degStr = formatDMS(p);
     return `${abbr} ${signName} ${degStr}`;

--- a/tests/planet-flags.test.js
+++ b/tests/planet-flags.test.js
@@ -106,7 +106,7 @@ test('combust planets show (C) in chart summary', async () => {
     let abbr = PLANET_ABBR[p.name] || p.name.slice(0, 2);
     if (p.retro) abbr += '(R)';
     if (p.combust) abbr += '(C)';
-    const signNum = res.signInHouse?.[p.house] || p.sign + 1;
+    const signNum = p.sign + 1;
     const signName = SIGN_NAMES[signNum - 1];
     const degStr = formatDMS(p);
     return `${abbr} ${signName} ${degStr}`;


### PR DESCRIPTION
## Summary
- derive planet sign names in `ChartSummary` from each planet's own `sign`
- drop `signInHouse` from `ChartSummary` so it's only used for chart rendering
- update summary-related tests to expect sign names from `p.sign`

## Testing
- `npm test` *(fails: numerous assertion mismatches in computePositions-related tests)*

------
https://chatgpt.com/codex/tasks/task_e_68b730b2cc18832bbdca9f181d975c0b