### PR TITLE
chore: adjust ephemeris path setup

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -1,18 +1,13 @@
 import { DateTime } from 'luxon';
-import { fileURLToPath } from 'node:url';
 import * as swe from '../../swisseph/index.js';
 
 const epheUrl = new URL('../../swisseph/ephe/', import.meta.url);
-await swe.ready;
-if (epheUrl.protocol === 'file:') {
+swe.ready.then(() => {
+  if (epheUrl.protocol === 'file:') swe.swe_set_ephe_path(epheUrl.pathname);
   try {
-    const ephePath = fileURLToPath(epheUrl);
-    swe.swe_set_ephe_path(ephePath);
+    swe.swe_set_sid_mode(swe.SE_SIDM_LAHIRI, 0, 0);
   } catch {}
-}
-try {
-  swe.swe_set_sid_mode(swe.SE_SIDM_LAHIRI, 0, 0);
-} catch {}
+});
 
 function lonToSignDeg(longitude) {
   const norm = ((longitude % 360) + 360) % 360;


### PR DESCRIPTION
## Summary
- remove fileURLToPath and use URL pathname to set ephemeris directory
- initialize Swiss ephemeris path and sidereal mode after module readiness

## Testing
- `npm test` *(fails: 22)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b734222724832b8941baefc18b0b14