### PR TITLE
Align Saturn test expectations with AstroSage D1 chart

### DIFF
--- a/tests/astrosage-compare.test.js
+++ b/tests/astrosage-compare.test.js
@@ -12,6 +12,8 @@ test('Darbhanga 1982-12-01 03:50 matches AstroSage', async () => {
   assert.strictEqual(am.signInHouse[7], 1);
 
   const planets = Object.fromEntries(am.planets.map((p) => [p.name, p]));
+  assert.strictEqual(planets.saturn.sign, 6, 'saturn sign');
+  assert.ok(!planets.saturn.retro, 'saturn direct');
   for (const p of Object.values(planets)) {
     for (const k of ['deg', 'min', 'sec']) {
       assert.strictEqual(typeof p[k], 'number', `${p.name} ${k}`);
@@ -24,7 +26,7 @@ test('Darbhanga 1982-12-01 03:50 matches AstroSage', async () => {
     mercury: 1,
     jupiter: 1,
     venus: 1,
-    saturn: 12,
+    saturn: 1,
     rahu: 9,
     ketu: 3,
   };
@@ -42,6 +44,8 @@ test('Darbhanga 1982-12-01 15:50 matches AstroSage', async () => {
   assert.strictEqual(pm.signInHouse[7], 8);
 
   const planets = Object.fromEntries(pm.planets.map((p) => [p.name, p]));
+  assert.strictEqual(planets.saturn.sign, 6, 'saturn sign');
+  assert.ok(!planets.saturn.retro, 'saturn direct');
   for (const p of Object.values(planets)) {
     for (const k of ['deg', 'min', 'sec']) {
       assert.strictEqual(typeof p[k], 'number', `${p.name} ${k}`);

--- a/tests/darbhanga-dec-1982.test.js
+++ b/tests/darbhanga-dec-1982.test.js
@@ -13,6 +13,7 @@ test('Darbhanga 1982-12-01 03:50 positions', async () => {
   );
   assert.strictEqual(res.signInHouse[1], res.ascSign);
   const planets = Object.fromEntries(res.planets.map((p) => [p.name, p]));
+  assert.strictEqual(planets.saturn.sign, 6, 'saturn sign');
   const expected = {
     sun: 2,
     moon: 8,
@@ -20,7 +21,7 @@ test('Darbhanga 1982-12-01 03:50 positions', async () => {
     venus: 1,
     mars: 6,
     jupiter: 1,
-    saturn: 12,
+    saturn: 1,
     rahu: 9,
     ketu: 3,
   };
@@ -35,7 +36,7 @@ test('Darbhanga 1982-12-01 03:50 positions', async () => {
     venus: false,
     mercury: true,
     jupiter: true,
-    saturn: true,
+    saturn: false,
     rahu: true,
     ketu: true,
   };
@@ -61,7 +62,7 @@ test('Darbhanga 1982-12-01 03:50 positions', async () => {
     assert.strictEqual(p.sec, exp.sec, `${name} sec`);
   }
 
-  const firstHouse = ['mercury', 'venus', 'jupiter'];
+  const firstHouse = ['mercury', 'venus', 'jupiter', 'saturn'];
   for (const name of firstHouse) {
     const p = planets[name];
     const exp = expectedDMS[name];

--- a/tests/planet-placement-regression.test.js
+++ b/tests/planet-placement-regression.test.js
@@ -30,6 +30,9 @@ const doc = { createElementNS: (ns, tag) => new Element(tag) };
 test('planet positions match AstroSage for sample chart', async () => {
   const { computePositions, renderNorthIndian, HOUSE_BBOXES } = await astro;
   const data = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
+  const planets = Object.fromEntries(data.planets.map((p) => [p.name, p]));
+  assert.strictEqual(planets.saturn.sign, 6, 'saturn sign');
+  assert.ok(!planets.saturn.retro, 'saturn direct');
   const expected = {
     sun: 2,
     moon: 8,
@@ -37,7 +40,7 @@ test('planet positions match AstroSage for sample chart', async () => {
     mercury: 1,
     jupiter: 1,
     venus: 1,
-    saturn: 12,
+    saturn: 1,
     rahu: 9,
     ketu: 3,
   };

--- a/tests/saturn-direct.test.js
+++ b/tests/saturn-direct.test.js
@@ -1,10 +1,11 @@
 import assert from 'node:assert';
 import test from 'node:test';
 import { computePositions } from '../src/lib/astro.js';
-test('Saturn is retrograde on 1982-12-01', async () => {
+test('Saturn is direct on 1982-12-01', async () => {
   const res = await computePositions('1982-12-01T00:00+00:00', 0, 0);
   const saturn = res.planets.find((p) => p.name === 'saturn');
-  assert.ok(saturn.retro, 'saturn should be retrograde');
+  assert.strictEqual(saturn.sign, 6, 'saturn sign');
+  assert.ok(!saturn.retro, 'saturn should be direct');
 });
 
 test('Saturn degree and direct motion on 1982-12-28', async () => {


### PR DESCRIPTION
## Summary
- update Saturn expectations across Darbhanga regression tests to house 1 Libra and direct motion
- validate Saturn’s sign and motion in comparison and regression suites
- adjust Saturn direct test to reflect direct motion on 1982-12-01

## Testing
- `node --test` *(fails: Darbhanga and Saturn suites out of sync with runtime ephemeris)*

------
https://chatgpt.com/codex/tasks/task_e_68bc34a44b48832ba906f094d56048e7