### PR TITLE
feat: configurable sidereal mode and node type

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ node -e "const fs=require('fs');fs.writeFileSync('public/cities.json',JSON.strin
 
 Alternatively, point `src/lib/offlineGeocoder.js` to a locally hosted [Nominatim](https://nominatim.org/) or [Pelias](https://pelias.io/) server and query it instead of the JSON file.
 
+## Calculation Options
+
+Chart computation helpers such as `calculateChart` and the `/api/positions` endpoint
+accept two optional settings:
+
+- `sidMode` – numeric code passed to Swiss Ephemeris' `swe_set_sid_mode`.
+  Defaults to `swe.SE_SIDM_LAHIRI` when omitted.
+- `nodeType` – `'true'` or `'mean'` to select whether lunar nodes are computed
+  using `SE_TRUE_NODE` or `SE_MEAN_NODE`. The default is `'true'`.
+
+If these options are not provided, the traditional Lahiri ayanamsa and true node
+are used.
+
 ## Deployment
 
 Build the project and deploy the generated `dist/` folder to any static hosting provider (Netlify, Vercel, etc.).

--- a/server/index.cjs
+++ b/server/index.cjs
@@ -56,7 +56,7 @@ async function getEphemeris() {
 }
 
 app.get('/api/positions', async (req, res) => {
-  const { datetime, tz, lat, lon } = req.query;
+  const { datetime, tz, lat, lon, sidMode, nodeType } = req.query;
   if (!datetime || !tz || !lat || !lon) {
     return res
       .status(400)
@@ -72,11 +72,14 @@ app.get('/api/positions', async (req, res) => {
       return res.status(400).json({ error: 'Invalid longitude parameter' });
     }
     const { compute_positions } = await getEphemeris();
+    const sidModeNum = sidMode ? parseInt(sidMode, 10) : undefined;
     const result = await compute_positions({
       datetime,
       tz,
       lat: latNum,
       lon: lonNum,
+      sidMode: sidModeNum,
+      nodeType,
     });
     res.json(result);
   } catch (err) {

--- a/src/calculateChart.js
+++ b/src/calculateChart.js
@@ -29,6 +29,8 @@ export default async function calculateChart({
   lat,
   lon,
   timezone,
+  sidMode,
+  nodeType,
 }) {
   let tz = timezone;
   if (!tz) {
@@ -42,5 +44,5 @@ export default async function calculateChart({
   const dt = DateTime.fromISO(`${date}T${time}`, { zone: tz });
   const dtISO = dt.toISO({ suppressMilliseconds: true });
 
-  return await computePositions(dtISO, lat, lon);
+  return await computePositions(dtISO, lat, lon, { sidMode, nodeType });
 }

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -174,7 +174,7 @@ function diamondPath(cx, cy, size = BOX_SIZE) {
   return `M ${cx} ${cy - size} L ${cx + size} ${cy} L ${cx} ${cy + size} L ${cx - size} ${cy} Z`;
 }
 
-async function computePositions(dtISOWithZone, lat, lon) {
+async function computePositions(dtISOWithZone, lat, lon, { sidMode, nodeType } = {}) {
   const dt = DateTime.fromISO(dtISOWithZone, { setZone: true });
   if (!dt.isValid) throw new Error('Invalid datetime');
 
@@ -183,6 +183,8 @@ async function computePositions(dtISOWithZone, lat, lon) {
     tz: dt.zoneName,
     lat,
     lon,
+    sidMode,
+    nodeType,
   });
 
   const ascSign = base.ascSign;

--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -37,11 +37,18 @@ function toUTC({ datetime, zone }) {
   return dt.toJSDate();
 }
 
-async function compute_positions({ datetime, tz, lat, lon }, sweInst = swe) {
+async function compute_positions(
+  { datetime, tz, lat, lon, sidMode, nodeType },
+  sweInst = swe
+) {
   await sweInst.ready;
   try {
     if (typeof sweInst.swe_set_sid_mode === 'function') {
-      sweInst.swe_set_sid_mode(sweInst.SE_SIDM_LAHIRI, 0, 0);
+      sweInst.swe_set_sid_mode(
+        sidMode ?? sweInst.SE_SIDM_LAHIRI,
+        0,
+        0
+      );
     }
   } catch {}
 
@@ -73,6 +80,9 @@ async function compute_positions({ datetime, tz, lat, lon }, sweInst = swe) {
     houses[i] = (ascStart + (i - 1) * 30) % 360;
   }
 
+  const nodeCode =
+    nodeType === 'mean' ? sweInst.SE_MEAN_NODE : sweInst.SE_TRUE_NODE;
+
   const planetCodes = {
     sun: sweInst.SE_SUN,
     moon: sweInst.SE_MOON,
@@ -84,11 +94,11 @@ async function compute_positions({ datetime, tz, lat, lon }, sweInst = swe) {
     uranus: sweInst.SE_URANUS,
     neptune: sweInst.SE_NEPTUNE,
     pluto: sweInst.SE_PLUTO,
-    rahu: sweInst.SE_TRUE_NODE,
+    rahu: nodeCode,
   };
 
   const planets = [];
-  const rahuData = sweInst.swe_calc_ut(jd, sweInst.SE_TRUE_NODE, flag);
+  const rahuData = sweInst.swe_calc_ut(jd, nodeCode, flag);
   const { sign: rSign, deg: rDeg, min: rMin, sec: rSec } = lonToSignDeg(
     rahuData.longitude
   );


### PR DESCRIPTION
## Summary
- allow `compute_positions` to accept `sidMode` and `nodeType`
- propagate options through chart utilities and server
- document new `sidMode` and `nodeType` options in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc5e1ae108832b8f3547fe25e3ffc7