### PR TITLE
Use Asia/Kolkata as default timezone fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ compare it against the AstroSage online chart using known reference data:
 
 1. Open the AstroSage birth chart calculator and set the location to
    **Darbhanga, India** (26.152° N, 85.897° E).
-2. Generate charts for these reference times in the India/Calcutta time zone:
+2. Generate charts for these reference times in the Asia/Kolkata time zone:
    - **1 December 1982, 03:50**
    - **1 December 1982, 15:50**
 3. Run this project and enter the same details. The ascendant sign and the

--- a/src/calculateChart.js
+++ b/src/calculateChart.js
@@ -37,7 +37,7 @@ export default async function calculateChart({
     try {
       tz = getTimezoneName(lat, lon);
     } catch {
-      tz = 'Asia/Calcutta';
+      tz = 'Asia/Kolkata';
     }
   }
 


### PR DESCRIPTION
## Summary
- Switch fallback timezone in chart calculations from Asia/Calcutta to Asia/Kolkata
- Update documentation to reference Asia/Kolkata

## Testing
- `node -e "import('./src/lib/timezone.js').then(m=>console.log(m.getTimezoneName(20.5937,78.9629)));"`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc603425e4832b921760a6b1e5c82a