### PR TITLE
Add nakshatra data to ephemeris planets

### DIFF
--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -1,6 +1,5 @@
 import { DateTime } from 'luxon';
 import { compute_positions } from './ephemeris.js';
-import { longitudeToNakshatra } from './nakshatra.js';
 
 const svgNS = 'http://www.w3.org/2000/svg';
 
@@ -283,7 +282,7 @@ async function computePositions(dtISOWithZone, lat, lon, { sidMode, nodeType } =
     }
     const exalt = exaltedSign[p.name];
     const exalted = exalt !== undefined && sign === exalt;
-    const { nakshatra, pada } = longitudeToNakshatra(lon);
+    const { nakshatra, pada } = p;
     planets.push({
       name: p.name,
       sign,

--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -1,5 +1,6 @@
 import { DateTime } from 'luxon';
 import * as swe from '../../swisseph/index.js';
+import { longitudeToNakshatra } from './nakshatra.js';
 
 const epheUrl = new URL('../../swisseph/ephe/', import.meta.url);
 swe.ready.then(() => {
@@ -112,6 +113,7 @@ async function compute_positions(
         : lonToSignDeg(lon);
     const retro = data.longitudeSpeed < -speedThreshold;
     const house = Math.floor(((lon - ascStart + 360) % 360) / 30) + 1;
+    const { nakshatra, pada } = longitudeToNakshatra(lon);
     planets.push({
       name,
       sign,
@@ -122,10 +124,13 @@ async function compute_positions(
       speed: data.longitudeSpeed,
       retro,
       house,
+      nakshatra,
+      pada,
     });
   }
   const ketuLon = (rahuData.longitude + 180) % 360;
   const { sign: kSign, deg: kDeg, min: kMin, sec: kSec } = lonToSignDeg(ketuLon);
+  const { nakshatra: kNakshatra, pada: kPada } = longitudeToNakshatra(ketuLon);
   planets.push({
     name: 'ketu',
     sign: kSign,
@@ -136,6 +141,8 @@ async function compute_positions(
     speed: rahuData.longitudeSpeed,
     retro: rahuData.longitudeSpeed < -speedThreshold,
     house: Math.floor(((ketuLon - ascStart + 360) % 360) / 30) + 1,
+    nakshatra: kNakshatra,
+    pada: kPada,
   });
 
   return {

--- a/tests/pushkar-mishra-chart.test.js
+++ b/tests/pushkar-mishra-chart.test.js
@@ -22,8 +22,17 @@ test('Pushkar Mishra chart positions', async () => {
   assert.strictEqual(pada, 4);
   const actual = Object.fromEntries(
     res.planets.map((p) => {
-      const { nakshatra, pada } = longitudeToNakshatra(p.lon);
-      return [p.name, { sign: p.sign, deg: p.deg, min: p.min, sec: p.sec, nakshatra, pada }];
+      return [
+        p.name,
+        {
+          sign: p.sign,
+          deg: p.deg,
+          min: p.min,
+          sec: p.sec,
+          nakshatra: p.nakshatra,
+          pada: p.pada,
+        },
+      ];
     })
   );
   const expected = {


### PR DESCRIPTION
## Summary
- derive nakshatra and pada for each planet in the ephemeris results
- consume the new fields in astro helper instead of recalculating
- adjust Pushkar Mishra chart test to read nakshatra data from planets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bcdea6dec8832bb35aa2ae63e4022f