### PR TITLE
fix: skip Vite resolution for Node imports

### DIFF
--- a/swisseph/index.js
+++ b/swisseph/index.js
@@ -337,8 +337,8 @@ async function init(options) {
   try {
     if (typeof process === 'object') {
       const [{ readFile }, { WASI }] = await Promise.all([
-        import('fs/promises'),
-        import('wasi'),
+        import(/* @vite-ignore */ 'fs/promises'),
+        import(/* @vite-ignore */ 'wasi'),
       ]);
       const wasmPath = new URL('./wasm/swe.wasm', import.meta.url);
       const buffer = await readFile(wasmPath);


### PR DESCRIPTION
## Summary
- add `@vite-ignore` to Node-only dynamic imports in swisseph so Vite doesn't try to resolve them

## Testing
- `npm test`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68bce5b2d958832b809a56da434812ff