### PR TITLE
refactor: extract node import names

### DIFF
--- a/swisseph/index.js
+++ b/swisseph/index.js
@@ -336,9 +336,11 @@ async function init(options) {
   if (wasmModule) return wasmModule;
   try {
     if (typeof process === 'object') {
+      const fsMod = 'node:fs/promises';
+      const wasiMod = 'wasi';
       const [{ readFile }, { WASI }] = await Promise.all([
-        import(/* @vite-ignore */ 'fs/promises'),
-        import(/* @vite-ignore */ 'wasi'),
+        import(/* @vite-ignore */ fsMod),
+        import(/* @vite-ignore */ wasiMod),
       ]);
       const wasmPath = new URL('./wasm/swe.wasm', import.meta.url);
       const buffer = await readFile(wasmPath);


### PR DESCRIPTION
## Summary
- ensure Node-only modules are referenced by variables for dynamic import in `swisseph/index.js`

## Testing
- `npm run dev`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bceac95f4c832b93408a69aacfb78b