### PR TITLE
fix: tighten Node runtime WASI import

### DIFF
--- a/swisseph/index.js
+++ b/swisseph/index.js
@@ -335,9 +335,9 @@ let wasmModule;
 async function init(options) {
   if (wasmModule) return wasmModule;
   try {
-    if (typeof process === 'object') {
+    if (typeof process !== 'undefined' && process.versions?.node) {
       const fsMod = 'node:fs/promises';
-      const wasiMod = 'wasi';
+      const wasiMod = 'node:wasi';
       const [{ readFile }, { WASI }] = await Promise.all([
         import(/* @vite-ignore */ fsMod),
         import(/* @vite-ignore */ wasiMod),


### PR DESCRIPTION
## Summary
- ensure WASM initialization uses node-only check
- prefix Node built-in imports with `node:` and avoid Vite resolution

## Testing
- `npm run dev`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcef3eb628832b9dc13069d51ed6bc