### PR TITLE
Ensure WASI imports for WebAssembly instantiation

### DIFF
--- a/swisseph/index.js
+++ b/swisseph/index.js
@@ -414,11 +414,15 @@ async function init(options) {
           __syscall_readlinkat: () => 0,
         };
 
-        const imports = { env };
-        if (typeof WASI === 'function') {
-          const wasi = new WASI({ version: 'preview1' });
-          imports.wasi_snapshot_preview1 = wasi.wasiImport;
-        }
+        const wasiSnapshot =
+          typeof WASI === 'function'
+            ? new WASI({ version: 'preview1' }).wasiImport
+            : {
+                fd_write: () => 0,
+                fd_close: () => 0,
+                proc_exit: (code) => console.warn('WASI exit', code),
+              };
+        const imports = { env, wasi_snapshot_preview1: wasiSnapshot };
 
         const { instance } = await WebAssembly.instantiateStreaming(
           response,


### PR DESCRIPTION
## Summary
- Always provide a `wasi_snapshot_preview1` import when streaming the Swiss Ephemeris WASM module, using Node's `WASI` when available or a minimal stub otherwise

## Testing
- `npm test`
- `npm run build`
- `node -e "import('./swisseph/index.js').then(m => m.ready.then(() => console.log('module ready')).catch(e => { console.error('error', e); process.exit(1); }))"`


------
https://chatgpt.com/codex/tasks/task_e_68bcf544fa50832bba615cc4085ca802