### PR TITLE
Fix WASI stub for browser WebAssembly instantiation

### DIFF
--- a/swisseph/index.js
+++ b/swisseph/index.js
@@ -373,10 +373,8 @@ async function init(options) {
         __syscall_readlinkat: () => 0,
       };
       const wasi = new WASI({ version: 'preview1' });
-      const { instance } = await WebAssembly.instantiate(buffer, {
-        env,
-        wasi_snapshot_preview1: wasi.wasiImport,
-      });
+      const imports = { env, wasi_snapshot_preview1: wasi.wasiImport };
+      const { instance } = await WebAssembly.instantiate(buffer, imports);
       wasmModule = instance.exports;
     } else {
       if (
@@ -414,15 +412,24 @@ async function init(options) {
           __syscall_readlinkat: () => 0,
         };
 
-        const wasiSnapshot =
+        const wasiStub =
           typeof WASI === 'function'
             ? new WASI({ version: 'preview1' }).wasiImport
             : {
                 fd_write: () => 0,
+                fd_read: () => 0,
                 fd_close: () => 0,
+                fd_seek: () => 0,
+                fd_fdstat_get: () => 0,
+                fd_fdstat_set_flags: () => 0,
+                fd_prestat_get: () => 0,
+                fd_prestat_dir_name: () => 0,
+                random_get: () => 0,
+                environ_get: () => 0,
+                environ_sizes_get: () => 0,
                 proc_exit: (code) => console.warn('WASI exit', code),
               };
-        const imports = { env, wasi_snapshot_preview1: wasiSnapshot };
+        const imports = { env, wasi_snapshot_preview1: wasiStub };
 
         const { instance } = await WebAssembly.instantiateStreaming(
           response,


### PR DESCRIPTION
## Summary
- ensure the browser build supplies a full `wasi_snapshot_preview1` import, including stubs for `fd_read`, `fd_seek`, environment helpers, and other WASI functions
- refactor WASM loaders to assemble an `imports` object passed to `WebAssembly.instantiate`/`instantiateStreaming`

## Testing
- `node -e "const fs=require('fs');const wasm=fs.readFileSync('./swisseph/wasm/swe.wasm');const memory=new WebAssembly.Memory({initial:256,maximum:256});const env={memory,emscripten_memcpy_big:(d,s,n)=>{new Uint8Array(memory.buffer).copyWithin(d,s,s+n);return d;},emscripten_resize_heap:()=>0,__syscall_openat:()=>-1,__syscall_close:()=>0,__syscall_fcntl64:()=>0,__syscall_ioctl:()=>0,__syscall_newfstatat:()=>0,__syscall_getdents64:()=>0,__syscall_lstat64:()=>0,__syscall_stat64:()=>0,__syscall_unlinkat:()=>0,__syscall_mkdirat:()=>0,__syscall_renameat:()=>0,__syscall_symlinkat:()=>0,__syscall_rmdir:()=>0,__syscall_dup3:()=>0,__syscall_gettimeofday:()=>0,__syscall_prlimit64:()=>0,__syscall_rt_sigaction:()=>0,__syscall_uname:()=>0,__syscall_readlinkat:()=>0};const wasiStub={fd_write:()=>0,fd_read:()=>0,fd_close:()=>0,fd_seek:()=>0,fd_fdstat_get:()=>0,fd_fdstat_set_flags:()=>0,fd_prestat_get:()=>0,fd_prestat_dir_name:()=>0,random_get:()=>0,environ_get:()=>0,environ_sizes_get:()=>0,proc_exit:c=>console.warn('WASI exit',c)};WebAssembly.instantiate(wasm,{env,wasi_snapshot_preview1:wasiStub}).then(()=>console.log('instantiated')).catch(err=>console.error(err));"`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcf7459478832b91df4cb3c6cecce8