### PR TITLE
feat: include nakshatra and pada in chart summary

### DIFF
--- a/src/components/ChartSummary.jsx
+++ b/src/components/ChartSummary.jsx
@@ -44,7 +44,9 @@ export default function ChartSummary({ data }) {
     const signNum = p.sign + 1;
     const signName = SIGN_NAMES[signNum - 1];
     const degStr = formatDMS(p);
-    return { abbr, signName, degStr };
+    const nakshatra = p.nakshatra;
+    const pada = p.pada;
+    return { abbr, signName, degStr, nakshatra, pada };
   });
   return (
     <div className="backdrop-blur-md bg-amber-50 border border-amber-200 rounded-xl p-6 text-amber-900 mt-4">
@@ -52,11 +54,14 @@ export default function ChartSummary({ data }) {
       <p>Moon sign: {moonSign}</p>
       <table className="mt-4 text-left">
         <tbody>
-          {planetRows.map(({ abbr, signName, degStr }) => (
+          {planetRows.map(({ abbr, signName, degStr, nakshatra, pada }) => (
             <tr key={abbr}>
               <td className="pr-2">{abbr}</td>
-              <td>
+              <td className="pr-2">
                 {signName} {degStr}
+              </td>
+              <td>
+                {nakshatra} {pada}
               </td>
             </tr>
           ))}
@@ -80,6 +85,8 @@ ChartSummary.propTypes = {
         retro: PropTypes.bool,
         combust: PropTypes.bool,
         exalted: PropTypes.bool,
+        nakshatra: PropTypes.string,
+        pada: PropTypes.number,
       })
     ).isRequired,
   }).isRequired,

--- a/tests/chart-summary-nakshatra.test.js
+++ b/tests/chart-summary-nakshatra.test.js
@@ -1,0 +1,52 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
+
+const PLANET_ABBR = {
+  sun: 'Su',
+  moon: 'Mo',
+  mars: 'Ma',
+  mercury: 'Me',
+  jupiter: 'Ju',
+  venus: 'Ve',
+  saturn: 'Sa',
+  uranus: 'Ur',
+  neptune: 'Ne',
+  pluto: 'Pl',
+  rahu: 'Ra',
+  ketu: 'Ke',
+};
+
+function formatDMS(p) {
+  let d = p.deg;
+  let m = p.min;
+  let s = p.sec;
+  if (typeof m !== 'number' || typeof s !== 'number') {
+    const dVal = Math.floor(p.deg);
+    const mFloat = (p.deg - dVal) * 60;
+    const mVal = Math.floor(mFloat);
+    const sVal = Math.round((mFloat - mVal) * 60);
+    d = dVal;
+    m = mVal;
+    s = sVal;
+  }
+  return `${d}°${String(m).padStart(2, '0')}′${String(s).padStart(2, '0')}″`;
+}
+
+test('Darbhanga chart summary lists nakshatra and pada', async () => {
+  const { computePositions, SIGN_NAMES } = await astro;
+  const data = await computePositions('1982-12-01T03:50+05:30', 26.15216, 85.89707);
+  const rows = data.planets.map((p) => {
+    let abbr = PLANET_ABBR[p.name] || p.name.slice(0, 2);
+    if (p.retro) abbr += '(R)';
+    if (p.combust) abbr += '(C)';
+    if (p.exalted) abbr += '(Ex)';
+    const signNum = p.sign + 1;
+    const signName = SIGN_NAMES[signNum - 1];
+    const degStr = formatDMS(p);
+    return `${abbr} ${signName} ${degStr} ${p.nakshatra} ${p.pada}`;
+  });
+  const moonRow = rows.find((r) => r.startsWith('Mo'));
+  assert.ok(moonRow && moonRow.includes('Rohini 1'));
+});


### PR DESCRIPTION
## Summary
- show each planet's nakshatra and pada in the chart summary
- test that chart summary rows include nakshatra and pada

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcfeecdf54832b92a3ab1c5d3d873d