### PR TITLE
Default to mean node for sidereal calculations

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -39,7 +39,7 @@ function toUTC({ datetime, zone }) {
 }
 
 async function compute_positions(
-  { datetime, tz, lat, lon, sidMode, nodeType },
+  { datetime, tz, lat, lon, sidMode, nodeType = 'mean' },
   sweInst = swe
 ) {
   await sweInst.ready;

--- a/tests/ephemeris.test.js
+++ b/tests/ephemeris.test.js
@@ -87,6 +87,7 @@ test('house cusps and retrograde flags', async () => {
     SE_NEPTUNE: 9,
     SE_PLUTO: 10,
     SE_TRUE_NODE: 7,
+    SE_MEAN_NODE: 7,
     swe_julday: () => 0,
     swe_houses_ex: () => ({
       ascendant: 123,

--- a/tests/pushkar-mishra-chart.test.js
+++ b/tests/pushkar-mishra-chart.test.js
@@ -9,6 +9,7 @@ test('Pushkar Mishra chart positions', async () => {
     tz: 'Asia/Kolkata',
     lat: 26.152,
     lon: 85.897,
+    nodeType: 'mean',
   });
 
   const ascLon = res.ascendant.lon;

--- a/tests/pushkar-mishra-regression.test.js
+++ b/tests/pushkar-mishra-regression.test.js
@@ -30,6 +30,7 @@ test('Pushkar Mishra positions regression', async () => {
     tz: 'Asia/Kolkata',
     lat: 26.152,
     lon: 85.897,
+    nodeType: 'mean',
   });
 
   const bodies = { ascendant: { ...res.ascendant } };


### PR DESCRIPTION
## Summary
- Default ephemeris calculations to the mean lunar node
- Explicitly request mean node in Pushkar Mishra chart tests
- Extend ephemeris tests with mean node constant for mocked Swiss ephemeris

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd0113d218832b922bda8f7dd5efca