### PR TITLE
Allow configurable ayanamsha and house system

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,15 +57,19 @@ Alternatively, point `src/lib/offlineGeocoder.js` to a locally hosted [Nominatim
 ## Calculation Options
 
 Chart computation helpers such as `calculateChart` and the `/api/positions` endpoint
-accept two optional settings:
+accept these optional settings:
 
 - `sidMode` – numeric code passed to Swiss Ephemeris' `swe_set_sid_mode`.
   Defaults to `swe.SE_SIDM_LAHIRI` when omitted.
+- `houseSystem` – single-letter code for the desired house system passed to
+  `swe_houses_ex`. The default `'W'` uses whole-sign houses to match AstroSage's
+  Rāśi chart.
 - `nodeType` – `'true'` or `'mean'` to select whether lunar nodes are computed
-  using `SE_TRUE_NODE` or `SE_MEAN_NODE`. The default is `'true'`.
+  using `SE_TRUE_NODE` or `SE_MEAN_NODE`. The default is `'mean'`.
 
-If these options are not provided, the traditional Lahiri ayanamsa and true node
-are used.
+When these options are not provided the calculation assumes Lahiri ayanamsa,
+whole-sign houses and the mean lunar node, which mirrors AstroSage's
+configuration for the reference charts used in this project.
 
 ## Deployment
 

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -173,7 +173,12 @@ function diamondPath(cx, cy, size = BOX_SIZE) {
   return `M ${cx} ${cy - size} L ${cx + size} ${cy} L ${cx} ${cy + size} L ${cx - size} ${cy} Z`;
 }
 
-async function computePositions(dtISOWithZone, lat, lon, { sidMode, nodeType } = {}) {
+async function computePositions(
+  dtISOWithZone,
+  lat,
+  lon,
+  { sidMode, nodeType, houseSystem } = {}
+) {
   const dt = DateTime.fromISO(dtISOWithZone, { setZone: true });
   if (!dt.isValid) throw new Error('Invalid datetime');
 
@@ -184,14 +189,15 @@ async function computePositions(dtISOWithZone, lat, lon, { sidMode, nodeType } =
     lon,
     sidMode,
     nodeType,
+    houseSystem,
   });
 
   const ascSign = base.ascSign;
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) {
-    // In a whole-sign system the sign of each subsequent house simply advances
-    // by one from the ascendant sign.
-    signInHouse[h] = ((ascSign + h - 2 + 12) % 12) + 1;
+    const lon = base.houses[h];
+    const norm = ((lon % 360) + 360) % 360;
+    signInHouse[h] = Math.floor(norm / 30) + 1;
   }
   if (process.env.DEBUG_HOUSES) {
     console.log('signInHouse:', signInHouse);

--- a/tests/astroComparison.test.js
+++ b/tests/astroComparison.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import test from 'node:test';
+import * as swe from '../swisseph/index.js';
 
 const astro = import('../src/lib/astro.js');
 
@@ -29,7 +30,11 @@ const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
 test('computePositions matches AstroSage for Darbhanga 1982-12-01 03:50', async () => {
   const { computePositions, renderNorthIndian } = await astro;
-  const result = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
+  const result = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897, {
+    sidMode: swe.SE_SIDM_LAHIRI,
+    houseSystem: 'W',
+    nodeType: 'mean',
+  });
 
   // Ascendant sign
   assert.strictEqual(result.ascSign, 7);

--- a/tests/astrosage-compare.test.js
+++ b/tests/astrosage-compare.test.js
@@ -1,11 +1,16 @@
 import assert from 'node:assert';
 import test from 'node:test';
+import * as swe from '../swisseph/index.js';
 
 const astro = import('../src/lib/astro.js');
 
 test('Darbhanga 1982-12-01 03:50 matches AstroSage', async () => {
   const { computePositions } = await astro;
-  const am = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
+  const am = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897, {
+    sidMode: swe.SE_SIDM_LAHIRI,
+    houseSystem: 'W',
+    nodeType: 'mean',
+  });
   assert.strictEqual(am.ascSign, 7);
   assert.strictEqual(am.signInHouse[1], am.ascSign);
   assert.strictEqual(am.signInHouse[6], 12);
@@ -40,7 +45,11 @@ test('Darbhanga 1982-12-01 03:50 matches AstroSage', async () => {
 
 test('Darbhanga 1982-12-01 15:50 matches AstroSage', async () => {
   const { computePositions } = await astro;
-  const pm = await computePositions('1982-12-01T15:50+05:30', 26.152, 85.897);
+  const pm = await computePositions('1982-12-01T15:50+05:30', 26.152, 85.897, {
+    sidMode: swe.SE_SIDM_LAHIRI,
+    houseSystem: 'W',
+    nodeType: 'mean',
+  });
   assert.strictEqual(pm.ascSign, 2);
   assert.strictEqual(pm.signInHouse[1], pm.ascSign);
   assert.strictEqual(pm.signInHouse[6], 7);
@@ -75,14 +84,22 @@ test('Darbhanga 1982-12-01 15:50 matches AstroSage', async () => {
 
 test('Darbhanga 1982-12-01 03:50 sign sequence matches AstroSage', async () => {
   const { computePositions } = await astro;
-  const am = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
+  const am = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897, {
+    sidMode: swe.SE_SIDM_LAHIRI,
+    houseSystem: 'W',
+    nodeType: 'mean',
+  });
   const expected = [null, 7, 8, 9, 10, 11, 12, 1, 2, 3, 4, 5, 6];
   assert.deepStrictEqual(am.signInHouse, expected);
 });
 
 test('Darbhanga 1982-12-01 03:50: Mercury, Venus, Jupiter in house 1', async () => {
   const { computePositions } = await astro;
-  const res = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
+  const res = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897, {
+    sidMode: swe.SE_SIDM_LAHIRI,
+    houseSystem: 'W',
+    nodeType: 'mean',
+  });
   const planets = Object.fromEntries(res.planets.map((p) => [p.name, p]));
   for (const name of ['jupiter', 'mercury', 'venus']) {
     assert.strictEqual(planets[name].house, 1, `${name} house`);

--- a/tests/ephemeris.test.js
+++ b/tests/ephemeris.test.js
@@ -62,7 +62,7 @@ test('applies sidereal mode, converts to UTC, and uses provided coordinates', as
     jd: 0,
     lat: 26.152,
     lon: 85.897,
-    hsys: 'P',
+    hsys: 'W',
     flag: fakeSwe.SEFLG_SWIEPH | fakeSwe.SEFLG_SPEED | fakeSwe.SEFLG_SIDEREAL,
   });
 });

--- a/tests/planet-placement-regression.test.js
+++ b/tests/planet-placement-regression.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import test from 'node:test';
+import * as swe from '../swisseph/index.js';
 
 const astro = import('../src/lib/astro.js');
 
@@ -29,7 +30,11 @@ const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
 test('planet positions match AstroSage for sample chart', async () => {
   const { computePositions, renderNorthIndian, HOUSE_BBOXES } = await astro;
-  const data = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
+  const data = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897, {
+    sidMode: swe.SE_SIDM_LAHIRI,
+    houseSystem: 'W',
+    nodeType: 'mean',
+  });
   const planets = Object.fromEntries(data.planets.map((p) => [p.name, p]));
   assert.strictEqual(planets.saturn.sign, 5, 'saturn sign');
   assert.ok(planets.saturn.retro, 'saturn retro');

--- a/tests/pushkar-mishra-regression.test.js
+++ b/tests/pushkar-mishra-regression.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import test from 'node:test';
+import * as swe from '../swisseph/index.js';
 import { longitudeToNakshatra } from '../src/lib/nakshatra.js';
 
 // Verified values from AstroSage for Pushkar Mishra birth chart
@@ -31,6 +32,8 @@ test('Pushkar Mishra positions regression', async () => {
     lat: 26.152,
     lon: 85.897,
     nodeType: 'mean',
+    sidMode: swe.SE_SIDM_LAHIRI,
+    houseSystem: 'W',
   });
 
   const bodies = { ascendant: { ...res.ascendant } };

--- a/tests/reference-case.test.js
+++ b/tests/reference-case.test.js
@@ -1,5 +1,6 @@
 import assert from 'node:assert';
 import test from 'node:test';
+import * as swe from '../swisseph/index.js';
 
 const astro = import('../src/lib/astro.js');
 
@@ -29,7 +30,11 @@ const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
 test('reference charts for Darbhanga on 1982-12-01 match expected placements', async () => {
   const { computePositions, renderNorthIndian } = await astro;
-  const am = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
+  const am = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897, {
+    sidMode: swe.SE_SIDM_LAHIRI,
+    houseSystem: 'W',
+    nodeType: 'mean',
+  });
   assert.strictEqual(am.ascSign, 7);
   const amPlanets = Object.fromEntries(am.planets.map((p) => [p.name, p]));
   assert.strictEqual(amPlanets.sun.sign, 7);
@@ -68,7 +73,11 @@ test('reference charts for Darbhanga on 1982-12-01 match expected placements', a
     4
   );
 
-  const pm = await computePositions('1982-12-01T15:50+05:30', 26.152, 85.897);
+  const pm = await computePositions('1982-12-01T15:50+05:30', 26.152, 85.897, {
+    sidMode: swe.SE_SIDM_LAHIRI,
+    houseSystem: 'W',
+    nodeType: 'mean',
+  });
   assert.strictEqual(pm.ascSign, 2);
   const pmPlanets = Object.fromEntries(pm.planets.map((p) => [p.name, p]));
   assert.strictEqual(pmPlanets.sun.sign, 7);

--- a/tests/sign-sequence-astrosage.test.js
+++ b/tests/sign-sequence-astrosage.test.js
@@ -1,11 +1,16 @@
 import test from 'node:test';
 import assert from 'node:assert';
+import * as swe from '../swisseph/index.js';
 
 const astro = import('../src/lib/astro.js');
 
 test('sign sequence matches AstroSage for Darbhanga 1982-12-01 03:50', async () => {
   const { computePositions } = await astro;
-  const result = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
+  const result = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897, {
+    sidMode: swe.SE_SIDM_LAHIRI,
+    houseSystem: 'W',
+    nodeType: 'mean',
+  });
   // Ascendant sign should populate the first house
   assert.strictEqual(result.signInHouse[1], result.ascSign);
   // The sequence should progress sequentially


### PR DESCRIPTION
## Summary
- enable ayanamsha, house system, and node type configuration in compute positions
- apply AstroSage-equivalent settings in regression tests
- document default assumptions for sidereal calculations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd03e43a40832ba78cf9453f843b9b