### PR TITLE
Normalize zodiac sign indexing to 1-based

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ A single-page React application that renders an accurate North Indian style D1 (
 - Renders responsive North Indian (diamond-style) chart.
 - Dark, glassmorphic UI with Tailwind CSS.
 
+## Zodiac sign numbering
+
+All modules use 1–12 numbering for zodiac signs (1 = Aries, 12 = Pisces).
+Earlier revisions used 0-based indices; tests and UI helpers now follow the
+1-based convention consistently.
+
 ## Technology Stack
 
 - React + Vite

--- a/src/calculateChart.js
+++ b/src/calculateChart.js
@@ -4,9 +4,11 @@ import { DateTime } from 'luxon';
 import { getTimezoneName } from './lib/timezone.js';
 import { computePositions } from './lib/astro.js';
 
+// Convert an ecliptic longitude into a zodiac sign and degree components.
+// Signs are numbered 1–12 where 1 = Aries and 12 = Pisces.
 export function longitudeToSign(longitude) {
   longitude = ((longitude % 360) + 360) % 360;
-  const sign = Math.floor(longitude / 30); // 0..11
+  const sign = Math.floor(longitude / 30) + 1; // 1..12
   let rem = longitude % 30;
   let deg = Math.floor(rem);
   rem = (rem - deg) * 60;

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -19,7 +19,7 @@ const SIGN_BOX_CENTERS = [
   { cx: 0.25, cy: 0.125 }, // Pisces
 ];
 
-// Sign label helpers. By default signs are labelled 1-12.
+// Sign label helpers. Signs are numbered 1–12 (1 = Aries).
 const SIGN_NUMBERS = Array.from({ length: 12 }, (_, i) => String(i + 1));
 const SIGN_ABBREVIATIONS = [
   'Ar',
@@ -65,6 +65,7 @@ const PLANET_ABBR = {
   ketu: 'Ke',
 };
 
+// Retrieve a sign label by 0-based index (0 = Aries).
 function getSignLabel(index, { useAbbreviations = false } = {}) {
   const labels = useAbbreviations ? SIGN_ABBREVIATIONS : SIGN_NUMBERS;
   return labels[index] ?? String(index + 1);
@@ -173,6 +174,8 @@ function diamondPath(cx, cy, size = BOX_SIZE) {
   return `M ${cx} ${cy - size} L ${cx + size} ${cy} L ${cx} ${cy + size} L ${cx - size} ${cy} Z`;
 }
 
+// Wrapper around compute_positions that normalises output for the UI.
+// All sign values use 1-12 numbering (1 = Aries).
 async function computePositions(
   dtISOWithZone,
   lat,
@@ -212,17 +215,17 @@ async function computePositions(
     venus: 10,
     saturn: 15,
   };
-  // exaltation signs (0 = Aries)
+  // Exaltation signs using 1-12 numbering (1 = Aries).
   const exaltedSign = {
-    sun: 0,
-    moon: 1,
-    mars: 9,
-    mercury: 5,
-    jupiter: 3,
-    venus: 11,
-    saturn: 6,
-    rahu: 1,
-    ketu: 7,
+    sun: 1,
+    moon: 2,
+    mars: 10,
+    mercury: 6,
+    jupiter: 4,
+    venus: 12,
+    saturn: 7,
+    rahu: 2,
+    ketu: 8,
   };
 
   const planets = [];
@@ -251,12 +254,12 @@ async function computePositions(
   const sunLon = getCorrectedLon(sun);
 
   for (const p of base.planets) {
-    let sign = p.sign - 1;
+    let sign = p.sign;
     let d = p.deg;
     let m = p.min;
     let s = p.sec;
     if (typeof p.csign === 'number') {
-      sign = p.csign - 1;
+      sign = p.csign;
       d = p.cdeg;
       m = p.cmin;
       s = p.csec;

--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -10,6 +10,8 @@ swe.ready.then(() => {
   } catch {}
 });
 
+// Convert a longitude into sign and DMS components.
+// Signs are numbered 1–12 (1 = Aries, 12 = Pisces).
 function lonToSignDeg(longitude) {
   const norm = ((longitude % 360) + 360) % 360;
   let sign = Math.floor(norm / 30) + 1; // 1..12
@@ -163,6 +165,7 @@ async function compute_positions(
     pada: kPada,
   });
 
+  // ascSign and each planet.sign use 1–12 numbering (1 = Aries).
   return {
     ascSign,
     ascendant: { lon: raw.ascendant, sign: ascSign, deg: ascDeg, min: ascMin, sec: ascSec },

--- a/src/lib/summary.js
+++ b/src/lib/summary.js
@@ -34,7 +34,7 @@ function formatDMS(p) {
 export function summarizeChart(data) {
   const ascendant = SIGN_NAMES[data.ascSign - 1];
   const moon = data.planets.find((p) => p.name === 'moon');
-  const moonSign = SIGN_NAMES[moon?.sign ?? 0];
+  const moonSign = SIGN_NAMES[(moon?.sign ?? 1) - 1]; // 1-based sign numbers
   // keep index 0 empty so houses are 1‑indexed
   const houses = Array(13).fill('');
   for (let h = 1; h <= 12; h += 1) {

--- a/tests/astrosage-compare.test.js
+++ b/tests/astrosage-compare.test.js
@@ -17,7 +17,7 @@ test('Darbhanga 1982-12-01 03:50 matches AstroSage', async () => {
   assert.strictEqual(am.signInHouse[7], 1);
 
   const planets = Object.fromEntries(am.planets.map((p) => [p.name, p]));
-  assert.strictEqual(planets.saturn.sign, 7, 'saturn sign');
+  assert.strictEqual(planets.saturn.sign, 8, 'saturn sign');
   assert.ok(!planets.saturn.retro, 'saturn retro');
   for (const p of Object.values(planets)) {
     for (const k of ['deg', 'min', 'sec']) {
@@ -56,7 +56,7 @@ test('Darbhanga 1982-12-01 15:50 matches AstroSage', async () => {
   assert.strictEqual(pm.signInHouse[7], 8);
 
   const planets = Object.fromEntries(pm.planets.map((p) => [p.name, p]));
-  assert.strictEqual(planets.saturn.sign, 7, 'saturn sign');
+  assert.strictEqual(planets.saturn.sign, 8, 'saturn sign');
   assert.ok(!planets.saturn.retro, 'saturn retro');
   for (const p of Object.values(planets)) {
     for (const k of ['deg', 'min', 'sec']) {

--- a/tests/chart-summary-degrees.test.js
+++ b/tests/chart-summary-degrees.test.js
@@ -42,7 +42,7 @@ test('Darbhanga chart summary lists degrees and signs', async () => {
     if (p.retro) abbr += '(R)';
     if (p.combust) abbr += '(C)';
     if (p.exalted) abbr += '(Ex)';
-    const signNum = p.sign + 1;
+    const signNum = p.sign;
     const signName = SIGN_NAMES[signNum - 1];
     const degStr = formatDMS(p);
     return `${abbr} ${signName} ${degStr}`;

--- a/tests/chart-summary-nakshatra.test.js
+++ b/tests/chart-summary-nakshatra.test.js
@@ -42,7 +42,7 @@ test('Darbhanga chart summary lists nakshatra and pada', async () => {
     if (p.retro) abbr += '(R)';
     if (p.combust) abbr += '(C)';
     if (p.exalted) abbr += '(Ex)';
-    const signNum = p.sign + 1;
+    const signNum = p.sign;
     const signName = SIGN_NAMES[signNum - 1];
     const degStr = formatDMS(p);
     return `${abbr} ${signName} ${degStr} ${p.nakshatra} ${p.pada}`;

--- a/tests/darbhanga-dec-1982.test.js
+++ b/tests/darbhanga-dec-1982.test.js
@@ -13,7 +13,7 @@ test('Darbhanga 1982-12-01 03:50 positions', async () => {
   );
   assert.strictEqual(res.signInHouse[1], res.ascSign);
   const planets = Object.fromEntries(res.planets.map((p) => [p.name, p]));
-  assert.strictEqual(planets.saturn.sign, 7, 'saturn sign');
+  assert.strictEqual(planets.saturn.sign, 8, 'saturn sign');
   const expected = {
     sun: 3,
     moon: 9,

--- a/tests/jupiter-not-combust.test.js
+++ b/tests/jupiter-not-combust.test.js
@@ -10,9 +10,9 @@ test('Jupiter is not combust', async () => {
   const jupiter = planets.jupiter;
   const sun = planets.sun;
   const sunLon =
-    sun.sign * 30 + sun.deg + sun.min / 60 + sun.sec / 3600;
+    (sun.sign - 1) * 30 + sun.deg + sun.min / 60 + sun.sec / 3600;
   const jLon =
-    jupiter.sign * 30 + jupiter.deg + jupiter.min / 60 + jupiter.sec / 3600;
+    (jupiter.sign - 1) * 30 + jupiter.deg + jupiter.min / 60 + jupiter.sec / 3600;
   const diff = Math.abs((sunLon - jLon + 180) % 360 - 180);
   assert.ok(
     diff > 11,

--- a/tests/longitude-to-sign.test.js
+++ b/tests/longitude-to-sign.test.js
@@ -8,7 +8,7 @@ async function getFn() {
 test('longitudeToSign handles negative degrees', async () => {
   const longitudeToSign = await getFn();
   assert.deepStrictEqual(longitudeToSign(-5), {
-    sign: 11,
+    sign: 12,
     deg: 25,
     min: 0,
     sec: 0,
@@ -18,7 +18,7 @@ test('longitudeToSign handles negative degrees', async () => {
 test('longitudeToSign handles degrees over 360', async () => {
   const longitudeToSign = await getFn();
   assert.deepStrictEqual(longitudeToSign(365), {
-    sign: 0,
+    sign: 1,
     deg: 5,
     min: 0,
     sec: 0,
@@ -27,12 +27,12 @@ test('longitudeToSign handles degrees over 360', async () => {
 
 test('exact boundary cases', async () => {
   const fn = await getFn();
-  assert.deepStrictEqual(fn(0), { sign: 0, deg: 0, min: 0, sec: 0 });
+  assert.deepStrictEqual(fn(0), { sign: 1, deg: 0, min: 0, sec: 0 });
   assert.deepStrictEqual(fn(29.99), {
-    sign: 0,
+    sign: 1,
     deg: 29,
     min: 59,
     sec: 24,
   });
-  assert.deepStrictEqual(fn(30), { sign: 1, deg: 0, min: 0, sec: 0 });
+  assert.deepStrictEqual(fn(30), { sign: 2, deg: 0, min: 0, sec: 0 });
 });

--- a/tests/planet-flags.test.js
+++ b/tests/planet-flags.test.js
@@ -110,7 +110,7 @@ test('combust planets show (C) in chart summary', async () => {
     let abbr = PLANET_ABBR[p.name] || p.name.slice(0, 2);
     if (p.retro) abbr += '(R)';
     if (p.combust) abbr += '(C)';
-    const signNum = p.sign + 1;
+    const signNum = p.sign;
     const signName = SIGN_NAMES[signNum - 1];
     const degStr = formatDMS(p);
     return `${abbr} ${signName} ${degStr}`;

--- a/tests/planet-placement-regression.test.js
+++ b/tests/planet-placement-regression.test.js
@@ -36,7 +36,7 @@ test('planet positions match AstroSage for sample chart', async () => {
     nodeType: 'mean',
   });
   const planets = Object.fromEntries(data.planets.map((p) => [p.name, p]));
-  assert.strictEqual(planets.saturn.sign, 7, 'saturn sign');
+  assert.strictEqual(planets.saturn.sign, 8, 'saturn sign');
   assert.ok(!planets.saturn.retro, 'saturn retro');
   const expected = {
     sun: 3,

--- a/tests/reference-case.test.js
+++ b/tests/reference-case.test.js
@@ -37,13 +37,13 @@ test('reference charts for Darbhanga on 1982-12-01 match expected placements', a
   });
   assert.strictEqual(am.ascSign, 7);
   const amPlanets = Object.fromEntries(am.planets.map((p) => [p.name, p]));
-  assert.strictEqual(amPlanets.sun.sign, 8);
+  assert.strictEqual(amPlanets.sun.sign, 9);
   assert.strictEqual(amPlanets.sun.house, 3);
-  assert.strictEqual(amPlanets.moon.sign, 2);
+  assert.strictEqual(amPlanets.moon.sign, 3);
   assert.strictEqual(amPlanets.moon.house, 9);
-  assert.strictEqual(amPlanets.jupiter.sign, 7);
+  assert.strictEqual(amPlanets.jupiter.sign, 8);
   assert.strictEqual(amPlanets.jupiter.house, 2);
-  assert.strictEqual(amPlanets.saturn.sign, 7);
+  assert.strictEqual(amPlanets.saturn.sign, 8);
   assert.strictEqual(amPlanets.saturn.house, 2);
   // Ensure Mars and Rahu mirror updated placements
   assert.strictEqual(amPlanets.mars.house, 4);
@@ -80,9 +80,9 @@ test('reference charts for Darbhanga on 1982-12-01 match expected placements', a
   });
   assert.strictEqual(pm.ascSign, 2);
   const pmPlanets = Object.fromEntries(pm.planets.map((p) => [p.name, p]));
-  assert.strictEqual(pmPlanets.sun.sign, 8);
+  assert.strictEqual(pmPlanets.sun.sign, 9);
   assert.strictEqual(pmPlanets.sun.house, 8);
-  assert.strictEqual(pmPlanets.moon.sign, 2);
+  assert.strictEqual(pmPlanets.moon.sign, 3);
   assert.strictEqual(pmPlanets.moon.house, 2);
   assert.strictEqual(pmPlanets.jupiter.house, 7);
   assert.strictEqual(pmPlanets.saturn.house, 7);

--- a/tests/saturn-motion.test.js
+++ b/tests/saturn-motion.test.js
@@ -5,7 +5,7 @@ import { computePositions } from '../src/lib/astro.js';
 test('Saturn is direct on 1982-12-01', async () => {
   const res = await computePositions('1982-12-01T00:00+00:00', 0, 0);
   const saturn = res.planets.find((p) => p.name === 'saturn');
-  assert.strictEqual(saturn.sign, 7, 'saturn sign');
+  assert.strictEqual(saturn.sign, 8, 'saturn sign');
   assert.ok(!saturn.retro, 'saturn should be direct');
 });
 

--- a/tests/text-inside-polygons.test.js
+++ b/tests/text-inside-polygons.test.js
@@ -42,7 +42,7 @@ test('all text elements render inside their house polygons', async () => {
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) signInHouse[h] = h;
   const codes = ['aa', 'bb', 'cc', 'dd', 'ee', 'ff', 'gg', 'hh', 'ii', 'jj', 'kk', 'll'];
-  const planets = codes.map((name, i) => ({ name, sign: i, house: i + 1, deg: 0 }));
+  const planets = codes.map((name, i) => ({ name, sign: i + 1, house: i + 1, deg: 0 }));
   const expected = Object.fromEntries(codes.map((c, i) => [c, i + 1]));
   const data = { ascSign: 1, signInHouse, planets };
 


### PR DESCRIPTION
## Summary
- standardize sign calculations on 1–12 numbering
- clarify sign numbering in UI helpers and exaltation maps
- document sign convention and fix summary moon sign lookup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd16c4b810832ba3e3c885822bb882