### PR TITLE
feat: expose ascendant nakshatra and pada

### DIFF
--- a/src/components/ChartSummary.jsx
+++ b/src/components/ChartSummary.jsx
@@ -74,6 +74,14 @@ export default function ChartSummary({ data }) {
 ChartSummary.propTypes = {
   data: PropTypes.shape({
     ascSign: PropTypes.number.isRequired,
+    ascendant: PropTypes.shape({
+      sign: PropTypes.number,
+      deg: PropTypes.number,
+      min: PropTypes.number,
+      sec: PropTypes.number,
+      nakshatra: PropTypes.string,
+      pada: PropTypes.number,
+    }),
     planets: PropTypes.arrayOf(
       PropTypes.shape({
         name: PropTypes.string.isRequired,

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -196,6 +196,7 @@ async function computePositions(
   });
 
   const ascSign = base.ascSign;
+  const ascendant = base.ascendant;
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) {
     const lon = base.houses[h];
@@ -309,7 +310,7 @@ async function computePositions(
     });
   }
 
-  return { ascSign, signInHouse, planets };
+  return { ascSign, ascendant, signInHouse, planets };
 }
 
 function renderNorthIndian(svgEl, data, options = {}) {

--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -85,6 +85,9 @@ async function compute_positions(
   const { sign: ascSign, deg: ascDeg, min: ascMin, sec: ascSec } = lonToSignDeg(
     raw.ascendant
   );
+  const { nakshatra: ascNakshatra, pada: ascPada } = longitudeToNakshatra(
+    raw.ascendant
+  );
   const houses = raw.houses;
 
   function getHouse(lon) {
@@ -168,7 +171,15 @@ async function compute_positions(
   // ascSign and each planet.sign use 1–12 numbering (1 = Aries).
   return {
     ascSign,
-    ascendant: { lon: raw.ascendant, sign: ascSign, deg: ascDeg, min: ascMin, sec: ascSec },
+    ascendant: {
+      lon: raw.ascendant,
+      sign: ascSign,
+      deg: ascDeg,
+      min: ascMin,
+      sec: ascSec,
+      nakshatra: ascNakshatra,
+      pada: ascPada,
+    },
     houses,
     planets,
   };

--- a/src/lib/summary.js
+++ b/src/lib/summary.js
@@ -32,7 +32,11 @@ function formatDMS(p) {
 }
 
 export function summarizeChart(data) {
-  const ascendant = SIGN_NAMES[data.ascSign - 1];
+  const ascSignName = SIGN_NAMES[data.ascSign - 1];
+  let ascendant = ascSignName;
+  if (data.ascendant?.nakshatra && data.ascendant?.pada) {
+    ascendant += ` ${data.ascendant.nakshatra} ${data.ascendant.pada}`;
+  }
   const moon = data.planets.find((p) => p.name === 'moon');
   const moonSign = SIGN_NAMES[(moon?.sign ?? 1) - 1]; // 1-based sign numbers
   // keep index 0 empty so houses are 1‑indexed

--- a/tests/chart-summary-regression.test.js
+++ b/tests/chart-summary-regression.test.js
@@ -11,7 +11,7 @@ test('Chart summary for reference chart matches expected output', async () => {
   assert.strictEqual(data.signInHouse[1], data.ascSign);
   const summaryData = summarizeChart(data);
   assert.deepStrictEqual(summaryData, {
-    ascendant: 'Libra',
+    ascendant: 'Libra Swati 4',
     moonSign: 'Gemini',
     houses: [
       '',

--- a/tests/pushkar-mishra-chart.test.js
+++ b/tests/pushkar-mishra-chart.test.js
@@ -1,9 +1,7 @@
 import assert from 'node:assert';
 import test from 'node:test';
-import { longitudeToNakshatra } from '../src/lib/nakshatra.js';
-
 test('Pushkar Mishra chart positions', async () => {
-  const { compute_positions, lonToSignDeg } = await import('../src/lib/ephemeris.js');
+  const { compute_positions } = await import('../src/lib/ephemeris.js');
   const res = await compute_positions({
     datetime: '1982-12-01T03:50',
     tz: 'Asia/Kolkata',
@@ -11,16 +9,13 @@ test('Pushkar Mishra chart positions', async () => {
     lon: 85.897,
     nodeType: 'mean',
   });
-
-  const ascLon = res.ascendant.lon;
-  const { sign, deg, min, sec } = lonToSignDeg(ascLon);
-  const { nakshatra, pada } = longitudeToNakshatra(ascLon);
-  assert.strictEqual(sign, 7); // Libra
-  assert.strictEqual(deg, 19);
-  assert.strictEqual(min, 25);
-  assert.ok(Math.abs(sec - 57) <= 1);
-  assert.strictEqual(nakshatra, 'Swati');
-  assert.strictEqual(pada, 4);
+  const asc = res.ascendant;
+  assert.strictEqual(asc.sign, 7); // Libra
+  assert.strictEqual(asc.deg, 19);
+  assert.strictEqual(asc.min, 25);
+  assert.ok(Math.abs(asc.sec - 57) <= 1);
+  assert.strictEqual(asc.nakshatra, 'Swati');
+  assert.strictEqual(asc.pada, 4);
   const actual = Object.fromEntries(
     res.planets.map((p) => {
       return [

--- a/tests/pushkar-mishra-regression.test.js
+++ b/tests/pushkar-mishra-regression.test.js
@@ -1,7 +1,6 @@
 import assert from 'node:assert';
 import test from 'node:test';
 import * as swe from '../swisseph/index.js';
-import { longitudeToNakshatra } from '../src/lib/nakshatra.js';
 
 // Verified values from AstroSage for Pushkar Mishra birth chart
 const expected = {
@@ -36,11 +35,7 @@ test('Pushkar Mishra positions regression', async () => {
     houseSystem: 'W',
   });
 
-  const bodies = { ascendant: { ...res.ascendant } };
-  const asc = bodies.ascendant;
-  const { nakshatra, pada } = longitudeToNakshatra(asc.lon);
-  asc.nakshatra = nakshatra;
-  asc.pada = pada;
+  const bodies = { ascendant: res.ascendant };
   for (const p of res.planets) bodies[p.name] = p;
 
   for (const [name, exp] of Object.entries(expected)) {


### PR DESCRIPTION
## Summary
- compute Lagna nakshatra and pada in ephemeris
- expose ascendant details through computePositions and chart summary
- adjust tests for new ascendant data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd1aa52250832b95f3000ed4f88f81