### PR TITLE
fix: correct planet sign names in summary

### DIFF
--- a/src/components/ChartSummary.jsx
+++ b/src/components/ChartSummary.jsx
@@ -41,8 +41,7 @@ export default function ChartSummary({ data }) {
     if (p.exalted) flags.push('(Ex)');
     // Ensure combust planets render with a (C) marker alongside other flags.
     abbr += flags.join('');
-    const signNum = p.sign + 1;
-    const signName = SIGN_NAMES[signNum - 1];
+    const signName = SIGN_NAMES[p.sign - 1];
     const degStr = formatDMS(p);
     const nakshatra = p.nakshatra;
     const pada = p.pada;


### PR DESCRIPTION
## Summary
- remove extra offset when determining planetary sign names so summary displays the correct signs

## Testing
- `npm test tests/pushkar-mishra-chart.test.js tests/astrosage-compare.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd342897fc832b8d6860a265e6b26a