### PR TITLE
Add optional nakshatra abbreviations

### DIFF
--- a/server/index.cjs
+++ b/server/index.cjs
@@ -56,7 +56,7 @@ async function getEphemeris() {
 }
 
 app.get('/api/positions', async (req, res) => {
-  const { datetime, tz, lat, lon, sidMode, nodeType } = req.query;
+  const { datetime, tz, lat, lon, sidMode, nodeType, nakshatraAbbr } = req.query;
   if (!datetime || !tz || !lat || !lon) {
     return res
       .status(400)
@@ -80,6 +80,7 @@ app.get('/api/positions', async (req, res) => {
       lon: lonNum,
       sidMode: sidModeNum,
       nodeType,
+      nakshatraAbbr: nakshatraAbbr === 'true' || nakshatraAbbr === '1',
     });
     res.json(result);
   } catch (err) {

--- a/src/calculateChart.js
+++ b/src/calculateChart.js
@@ -33,6 +33,7 @@ export default async function calculateChart({
   timezone,
   sidMode,
   nodeType,
+  nakshatraAbbr,
 }) {
   let tz = timezone;
   if (!tz) {
@@ -46,5 +47,9 @@ export default async function calculateChart({
   const dt = DateTime.fromISO(`${date}T${time}`, { zone: tz });
   const dtISO = dt.toISO({ suppressMilliseconds: true });
 
-  return await computePositions(dtISO, lat, lon, { sidMode, nodeType });
+  return await computePositions(dtISO, lat, lon, {
+    sidMode,
+    nodeType,
+    nakshatraAbbr,
+  });
 }

--- a/src/components/BirthForm.jsx
+++ b/src/components/BirthForm.jsx
@@ -15,6 +15,7 @@ export default function BirthForm({ onSubmit, loading }) {
     lat: null,
     lon: null,
     timezone: 'Asia/Calcutta',
+    nakshatraAbbr: false,
   });
   const [suggestions, setSuggestions] = useState([]);
   const timezones = Intl.supportedValuesOf('timeZone');
@@ -51,7 +52,8 @@ export default function BirthForm({ onSubmit, loading }) {
   };
 
   const handleChange = (e) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
+    const { name, type, value, checked } = e.target;
+    setForm({ ...form, [name]: type === 'checkbox' ? checked : value });
   };
 
   const parsedDate = form.date ? DateTime.fromJSDate(form.date).toISODate() : null;
@@ -86,6 +88,7 @@ export default function BirthForm({ onSubmit, loading }) {
       lat: form.lat,
       lon: form.lon,
       timezone: form.timezone,
+      nakshatraAbbr: form.nakshatraAbbr,
     });
   };
 
@@ -196,6 +199,19 @@ export default function BirthForm({ onSubmit, loading }) {
             </option>
           ))}
         </select>
+      </div>
+      <div className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          id="nakshatraAbbr"
+          name="nakshatraAbbr"
+          checked={form.nakshatraAbbr}
+          onChange={handleChange}
+          className="h-4 w-4"
+        />
+        <label htmlFor="nakshatraAbbr" className="select-none">
+          Use nakshatra abbreviations
+        </label>
       </div>
       <button type="submit" disabled={!valid || loading} className={buttonClasses}>
         {loading ? 'Calculating...' : 'Generate Chart'}

--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -180,7 +180,7 @@ async function computePositions(
   dtISOWithZone,
   lat,
   lon,
-  { sidMode, nodeType, houseSystem } = {}
+  { sidMode, nodeType, houseSystem, nakshatraAbbr } = {}
 ) {
   const dt = DateTime.fromISO(dtISOWithZone, { setZone: true });
   if (!dt.isValid) throw new Error('Invalid datetime');
@@ -193,6 +193,7 @@ async function computePositions(
     sidMode,
     nodeType,
     houseSystem,
+    nakshatraAbbr,
   });
 
   const ascSign = base.ascSign;

--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -37,6 +37,7 @@ async function compute_positions(
     sidMode,
     nodeType = 'mean',
     houseSystem = 'W',
+    nakshatraAbbr = false,
   },
   sweInst = swe
 ) {
@@ -74,7 +75,8 @@ async function compute_positions(
     raw.ascendant
   );
   const { nakshatra: ascNakshatra, pada: ascPada } = longitudeToNakshatra(
-    raw.ascendant
+    raw.ascendant,
+    { useAbbreviations: nakshatraAbbr }
   );
   const houses = raw.houses;
 
@@ -124,7 +126,9 @@ async function compute_positions(
         : lonToSignDeg(lon);
     const retro = data.longitudeSpeed < -speedThreshold;
     const house = getHouse(lon);
-    const { nakshatra, pada } = longitudeToNakshatra(lon);
+    const { nakshatra, pada } = longitudeToNakshatra(lon, {
+      useAbbreviations: nakshatraAbbr,
+    });
     planets.push({
       name,
       sign,
@@ -141,7 +145,10 @@ async function compute_positions(
   }
   const ketuLon = (rahuData.longitude + 180) % 360;
   const { sign: kSign, deg: kDeg, min: kMin, sec: kSec } = lonToSignDeg(ketuLon);
-  const { nakshatra: kNakshatra, pada: kPada } = longitudeToNakshatra(ketuLon);
+  const { nakshatra: kNakshatra, pada: kPada } = longitudeToNakshatra(
+    ketuLon,
+    { useAbbreviations: nakshatraAbbr }
+  );
   planets.push({
     name: 'ketu',
     sign: kSign,

--- a/src/lib/nakshatra.js
+++ b/src/lib/nakshatra.js
@@ -28,12 +28,54 @@ const NAKSHATRA_NAMES = [
   'Revati',
 ];
 
-function longitudeToNakshatra(lon) {
+// Common four-letter abbreviations corresponding to the full names above.
+// These provide short but still recognisable labels for UI display.
+const NAKSHATRA_ABBREVIATIONS = [
+  'Aswi',
+  'Bhar',
+  'Krit',
+  'Rohi',
+  'Mrig',
+  'Ardr',
+  'Puna',
+  'Push',
+  'Ashl',
+  'Magh',
+  'PPhl',
+  'UPhl',
+  'Hast',
+  'Chit',
+  'Swat',
+  'Vish',
+  'Anur',
+  'Jyes',
+  'Mula',
+  'PAsa',
+  'UAsa',
+  'Shra',
+  'Dhan',
+  'Shat',
+  'PBha',
+  'UBha',
+  'Reva',
+];
+
+function longitudeToNakshatra(lon, { useAbbreviations = false } = {}) {
   const norm = ((lon % 360) + 360) % 360;
   const segment = 360 / 27; // 13°20'
   const index = Math.floor(norm / segment);
   const pada = Math.floor((norm % segment) / (segment / 4)) + 1;
-  return { nakshatra: NAKSHATRA_NAMES[index], pada };
+  const names = useAbbreviations ? NAKSHATRA_ABBREVIATIONS : NAKSHATRA_NAMES;
+  return { nakshatra: names[index], pada };
 }
 
-export { NAKSHATRA_NAMES, longitudeToNakshatra };
+const NAKSHATRA_NAME_TO_ABBR = Object.fromEntries(
+  NAKSHATRA_NAMES.map((name, i) => [name, NAKSHATRA_ABBREVIATIONS[i]])
+);
+
+export {
+  NAKSHATRA_NAMES,
+  NAKSHATRA_ABBREVIATIONS,
+  NAKSHATRA_NAME_TO_ABBR,
+  longitudeToNakshatra,
+};

--- a/tests/nakshatra-abbr.test.js
+++ b/tests/nakshatra-abbr.test.js
@@ -1,0 +1,18 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+const astro = import('../src/lib/astro.js');
+
+test('computePositions returns nakshatra abbreviations when requested', async () => {
+  const { computePositions } = await astro;
+  const data = await computePositions(
+    '1982-12-01T03:50+05:30',
+    26.152,
+    85.897,
+    { nakshatraAbbr: true }
+  );
+  const mercury = data.planets.find((p) => p.name === 'mercury');
+  assert.strictEqual(mercury.nakshatra, 'Jyes');
+  const moon = data.planets.find((p) => p.name === 'moon');
+  assert.strictEqual(moon.nakshatra, 'Rohi');
+});


### PR DESCRIPTION
## Summary
- map full nakshatra names to common abbreviations and allow `longitudeToNakshatra` to return either form
- plumb a `nakshatraAbbr` flag through position calculations and API
- expose a checkbox in the UI to toggle nakshatra abbreviations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd3b2f1b60832baf0833ddf5af9e13