### PR TITLE
Expose node type selection

### DIFF
--- a/src/calculateChart.js
+++ b/src/calculateChart.js
@@ -32,7 +32,7 @@ export default async function calculateChart({
   lon,
   timezone,
   sidMode,
-  nodeType,
+  nodeType = 'mean',
   nakshatraAbbr,
 }) {
   let tz = timezone;

--- a/src/components/BirthForm.jsx
+++ b/src/components/BirthForm.jsx
@@ -15,6 +15,7 @@ export default function BirthForm({ onSubmit, loading }) {
     lat: null,
     lon: null,
     timezone: 'Asia/Calcutta',
+    nodeType: 'mean',
     nakshatraAbbr: false,
   });
   const [suggestions, setSuggestions] = useState([]);
@@ -88,6 +89,7 @@ export default function BirthForm({ onSubmit, loading }) {
       lat: form.lat,
       lon: form.lon,
       timezone: form.timezone,
+      nodeType: form.nodeType,
       nakshatraAbbr: form.nakshatraAbbr,
     });
   };
@@ -198,6 +200,18 @@ export default function BirthForm({ onSubmit, loading }) {
               {tz}
             </option>
           ))}
+        </select>
+      </div>
+      <div>
+        <label className="block mb-1">Node Type</label>
+        <select
+          name="nodeType"
+          value={form.nodeType}
+          onChange={handleChange}
+          className="w-full p-2 rounded bg-slate-800 border border-slate-700"
+        >
+          <option value="mean">Mean</option>
+          <option value="true">True</option>
         </select>
       </div>
       <div className="flex items-center gap-2">

--- a/tests/node-type-longitude.test.js
+++ b/tests/node-type-longitude.test.js
@@ -1,0 +1,36 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+import * as swe from '../swisseph/index.js';
+
+const ephemeris = import('../src/lib/ephemeris.js');
+
+test('changing nodeType updates lunar node longitude', async () => {
+  const { compute_positions } = await ephemeris;
+
+  const base = {
+    datetime: '2000-01-01T00:00',
+    tz: 'UTC',
+    lat: 0,
+    lon: 0,
+  };
+
+  const mean = await compute_positions({ ...base, nodeType: 'mean' });
+  const trueNode = await compute_positions({ ...base, nodeType: 'true' });
+
+  const meanLon = mean.planets.find((p) => p.name === 'rahu').lon;
+  const trueLon = trueNode.planets.find((p) => p.name === 'rahu').lon;
+
+  await swe.ready;
+  swe.swe_set_ephe_path('./swisseph/ephe');
+  swe.swe_set_sid_mode(swe.SE_SIDM_LAHIRI, 0, 0);
+  const jd = swe.swe_julday(2000, 1, 1, 0, swe.SE_GREG_CAL);
+  const flag = swe.SEFLG_SWIEPH | swe.SEFLG_SPEED | swe.SEFLG_SIDEREAL;
+
+  const expectedMean = swe.swe_calc_ut(jd, swe.SE_MEAN_NODE, flag).longitude;
+  const expectedTrue = swe.swe_calc_ut(jd, swe.SE_TRUE_NODE, flag).longitude;
+
+  assert.ok(Math.abs(meanLon - expectedMean) < 1e-6);
+  assert.ok(Math.abs(trueLon - expectedTrue) < 1e-6);
+});
+


### PR DESCRIPTION
## Summary
- allow choosing mean or true lunar node when calculating charts
- add regression test for lunar node types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd3d9396c8832b99af978421cd5020