### PR TITLE
Add tests for true lunar node and document nodeType options

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,11 @@ accept these optional settings:
   `swe_houses_ex`. The default `'W'` uses whole-sign houses to match AstroSage's
   Rāśi chart.
 - `nodeType` – `'true'` or `'mean'` to select whether lunar nodes are computed
-  using `SE_TRUE_NODE` or `SE_MEAN_NODE`. The default is `'mean'`.
+  using `SE_TRUE_NODE` or `SE_MEAN_NODE`. `'mean'` uses the smoothed average
+  position (AstroSage's default) while `'true'` includes the node's small
+  oscillation. For the reference Darbhanga chart both options place Rahu and
+  Ketu in Gemini/Sagittarius, though the longitudes differ by about a degree.
+  The default is 'mean'.
 
 When these options are not provided the calculation assumes Lahiri ayanamsa,
 whole-sign houses and the mean lunar node, which mirrors AstroSage's

--- a/tests/astrosage-compare.test.js
+++ b/tests/astrosage-compare.test.js
@@ -106,3 +106,30 @@ test('Darbhanga 1982-12-01 03:50: Mercury and Venus in house 2, Jupiter in house
     assert.strictEqual(planets[name].house, house, `${name} house`);
   }
 });
+
+// Using the "true" node accounts for the lunar node's small oscillation.
+// AstroSage labels this option "True Node". For the reference chart the
+// nodes should still fall in Gemini (Rahu) and Sagittarius (Ketu).
+test('Darbhanga 1982-12-01 03:50 true node matches AstroSage', async () => {
+  const { computePositions } = await astro;
+  const res = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897, {
+    sidMode: swe.SE_SIDM_LAHIRI,
+    houseSystem: 'W',
+    nodeType: 'true',
+  });
+  const planets = Object.fromEntries(res.planets.map((p) => [p.name, p]));
+  assert.strictEqual(planets.rahu.sign, 3); // Gemini
+  assert.strictEqual(planets.ketu.sign, 9); // Sagittarius
+});
+
+test('Darbhanga 1982-12-01 15:50 true node matches AstroSage', async () => {
+  const { computePositions } = await astro;
+  const res = await computePositions('1982-12-01T15:50+05:30', 26.152, 85.897, {
+    sidMode: swe.SE_SIDM_LAHIRI,
+    houseSystem: 'W',
+    nodeType: 'true',
+  });
+  const planets = Object.fromEntries(res.planets.map((p) => [p.name, p]));
+  assert.strictEqual(planets.rahu.sign, 3); // Gemini
+  assert.strictEqual(planets.ketu.sign, 9); // Sagittarius
+});

--- a/tests/node-type-longitude.test.js
+++ b/tests/node-type-longitude.test.js
@@ -5,6 +5,11 @@ import * as swe from '../swisseph/index.js';
 
 const ephemeris = import('../src/lib/ephemeris.js');
 
+// Swiss Ephemeris supports two flavours of the lunar nodes:
+// the smoothed "mean" node and the oscillating "true" node.
+// This test verifies that our wrapper swaps the underlying
+// Swiss Ephemeris call based on the `nodeType` option.
+
 test('changing nodeType updates lunar node longitude', async () => {
   const { compute_positions } = await ephemeris;
 

--- a/tests/pushkar-mishra-chart.test.js
+++ b/tests/pushkar-mishra-chart.test.js
@@ -48,3 +48,19 @@ test('Pushkar Mishra chart positions', async () => {
   assert.deepStrictEqual(actual, expected);
 });
 
+// Switching to the "true" node should adjust the lunar nodes by about a
+// degree while keeping them in Gemini/Sagittarius for this chart.
+test('Pushkar Mishra chart with true node', async () => {
+  const { compute_positions } = await import('../src/lib/ephemeris.js');
+  const res = await compute_positions({
+    datetime: '1982-12-01T03:50',
+    tz: 'Asia/Kolkata',
+    lat: 26.152,
+    lon: 85.897,
+    nodeType: 'true',
+  });
+  const planets = Object.fromEntries(res.planets.map((p) => [p.name, p]));
+  assert.strictEqual(planets.rahu.sign, 3); // Gemini
+  assert.strictEqual(planets.ketu.sign, 9); // Sagittarius
+});
+


### PR DESCRIPTION
## Summary
- document difference between `nodeType: 'mean'` and `nodeType: 'true'`
- add tests exercising true node positions for reference birth charts
- explain mean vs true node in node-type test comment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd4be54520832b8142bb8e9e4e650b