### PR TITLE
Normalize DMS rollover in lonToSignDeg

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -20,6 +20,19 @@ function lonToSignDeg(longitude) {
   rem = (rem - deg) * 60;
   let min = Math.floor(rem);
   let sec = Math.round((rem - min) * 60);
+  if (sec === 60) {
+    sec = 0;
+    min += 1;
+  }
+  if (min === 60) {
+    min = 0;
+    deg += 1;
+  }
+  if (deg === 30) {
+    deg = 0;
+    sign += 1;
+    if (sign === 13) sign = 1;
+  }
   return { sign, deg, min, sec };
 }
 


### PR DESCRIPTION
## Summary
- Normalize longitude components when seconds or minutes round up to 60 and degrees to 30

## Testing
- `npm test -- tests/pushkar-mishra-regression.test.js tests/pushkar-mishra-chart.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd5b9c893c832bae0600b4ad179257