### PR TITLE
chore: sync chart tests with AstroSage reference

### DIFF
--- a/tests/chart-summary-degrees.test.js
+++ b/tests/chart-summary-degrees.test.js
@@ -36,7 +36,7 @@ function formatDMS(p) {
 
 test('Darbhanga chart summary lists degrees and signs', async () => {
   const { computePositions, SIGN_NAMES } = await astro;
-  const data = await computePositions('1982-12-01T03:50+05:30', 26.15216, 85.89707);
+  const data = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
   const rows = data.planets.map((p) => {
     let abbr = PLANET_ABBR[p.name] || p.name.slice(0, 2);
     if (p.retro) abbr += '(R)';

--- a/tests/chart-summary-nakshatra.test.js
+++ b/tests/chart-summary-nakshatra.test.js
@@ -36,7 +36,7 @@ function formatDMS(p) {
 
 test('Darbhanga chart summary lists nakshatra and pada', async () => {
   const { computePositions, SIGN_NAMES } = await astro;
-  const data = await computePositions('1982-12-01T03:50+05:30', 26.15216, 85.89707);
+  const data = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
   const rows = data.planets.map((p) => {
     let abbr = PLANET_ABBR[p.name] || p.name.slice(0, 2);
     if (p.retro) abbr += '(R)';

--- a/tests/darbhanga-dec-1982.test.js
+++ b/tests/darbhanga-dec-1982.test.js
@@ -5,11 +5,11 @@ const astro = import('../src/lib/astro.js');
 
 test('Darbhanga 1982-12-01 03:50 positions', async () => {
   const { computePositions } = await astro;
-  const res = await computePositions('1982-12-01T03:50+05:30', 26.15216, 85.89707);
+  const res = await computePositions('1982-12-01T03:50+05:30', 26.152, 85.897);
   assert.strictEqual(res.ascSign, 7);
   assert.strictEqual(res.ascendant.deg, 12);
   assert.strictEqual(res.ascendant.min, 17);
-  assert.ok(Math.abs(res.ascendant.sec - 6) <= 1);
+  assert.strictEqual(res.ascendant.sec, 6);
   assert.strictEqual(res.ascendant.nakshatra, 'Swati');
   assert.strictEqual(res.ascendant.pada, 2);
   assert.deepStrictEqual(


### PR DESCRIPTION
## Summary
- use truncated Darbhanga coordinates in chart regression tests
- check ascendant second exactly and keep expected planet degrees
- keep nakshatra/pada assertions after coordinate sync

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd5cd7cb88832bba12b63e133d0713