### PR TITLE
Tighten Pushkar Mishra regression tolerance

### DIFF
--- a/tests/pushkar-mishra-regression.test.js
+++ b/tests/pushkar-mishra-regression.test.js
@@ -21,7 +21,7 @@ const expected = {
 
 const toArcminutes = ({ sign, deg, min, sec }) => ((sign - 1) * 30 + deg) * 60 + min + sec / 60;
 
-const TOLERANCE = 0.5; // arcminutes
+const TOLERANCE = 0.05; // arcminutes
 
 test('Pushkar Mishra positions regression', async () => {
   const { compute_positions } = await import('../src/lib/ephemeris.js');


### PR DESCRIPTION
## Summary
- Reduce tolerance in Pushkar Mishra regression test to 0.05 arcminutes for stricter validation.

## Testing
- `npm test tests/pushkar-mishra-regression.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd77330f18832b83440eb911a2f717