### PR TITLE
Clarify longitude conversion truncation

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -14,13 +14,12 @@ swe.ready.then(() => {
 // Signs are numbered 1–12 (1 = Aries, 12 = Pisces).
 function lonToSignDeg(longitude) {
   const norm = ((longitude % 360) + 360) % 360;
-  const sign = Math.trunc(norm / 30) + 1; // 1..12
-  const rem = norm % 30;
-  const deg = Math.trunc(rem);
-  const remMin = (rem - deg) * 60;
-  const min = Math.trunc(remMin);
-  // AstroSage truncates fractional seconds instead of rounding.
-  const sec = Math.trunc((remMin - min) * 60);
+  // AstroSage truncates fractional components instead of rounding.
+  const totalSeconds = Math.trunc(norm * 3600);
+  const sign = Math.floor(totalSeconds / (30 * 3600)) + 1; // 1..12
+  const deg = Math.floor(totalSeconds / 3600) % 30;
+  const min = Math.floor(totalSeconds / 60) % 60;
+  const sec = totalSeconds % 60;
   return { sign, deg, min, sec };
 }
 

--- a/tests/lon-to-sign-deg.test.js
+++ b/tests/lon-to-sign-deg.test.js
@@ -5,7 +5,7 @@ async function getFn() {
   return (await import('../src/lib/ephemeris.js')).lonToSignDeg;
 }
 
-test('lonToSignDeg truncates seconds per AstroSage', async () => {
+test('lonToSignDeg truncates fractional components per AstroSage', async () => {
   const lonToSignDeg = await getFn();
   const lon = 14 + 46 / 60 + 57.99 / 3600;
   assert.deepStrictEqual(lonToSignDeg(lon), {
@@ -13,5 +13,16 @@ test('lonToSignDeg truncates seconds per AstroSage', async () => {
     deg: 14,
     min: 46,
     sec: 57,
+  });
+});
+
+test('lonToSignDeg does not round up at sign boundary', async () => {
+  const lonToSignDeg = await getFn();
+  const lon = 29 + 59 / 60 + 59.99 / 3600;
+  assert.deepStrictEqual(lonToSignDeg(lon), {
+    sign: 1,
+    deg: 29,
+    min: 59,
+    sec: 59,
   });
 });


### PR DESCRIPTION
## Summary
- compute sign/degree/minute/second from truncated total seconds to match AstroSage behavior
- extend lonToSignDeg tests to cover boundary cases without rounding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bd95ef2540832b8381f57986f3afd1