### PR TITLE
Add negative longitude truncation test for lonToSignDeg

### DIFF
--- a/tests/lon-to-sign-deg.test.js
+++ b/tests/lon-to-sign-deg.test.js
@@ -26,3 +26,14 @@ test('lonToSignDeg does not round up at sign boundary', async () => {
     sec: 59,
   });
 });
+
+test('lonToSignDeg normalizes and truncates negative longitudes', async () => {
+  const lonToSignDeg = await getFn();
+  const lon = -(0.5 / 3600); // -0°0′0.5″ -> 359°59′59.5″
+  assert.deepStrictEqual(lonToSignDeg(lon), {
+    sign: 12,
+    deg: 29,
+    min: 59,
+    sec: 59,
+  });
+});


### PR DESCRIPTION
## Summary
- Clarify lonToSignDeg uses truncation with negative longitude example
- Ensure ephemeris conversions match AstroSage behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bda64b6588832b81bee7969d030cfa