### PR TITLE
refactor: inline dynamic swisseph import

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -3,8 +3,7 @@ import express from '../express/index.cjs';
 import path from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 
-// Placeholder for the Swiss Ephemeris library which will be loaded dynamically.
-let swisseph;
+// The Swiss Ephemeris library is loaded dynamically when the server starts.
 
 // --- Initialization ---
 
@@ -76,7 +75,7 @@ export default app;
 
 (async () => {
   try {
-    swisseph = await import('../swisseph/index.js');
+    const swisseph = await import('../swisseph/index.js');
     await swisseph.ready;
     swisseph.swe_set_ephe_path(ephemerisPath);
     swisseph.swe_set_sid_mode(swisseph.SE_SIDM_LAHIRI, 0, 0);


### PR DESCRIPTION
## Summary
- load Swiss Ephemeris dynamically and wait for initialization before setting ephemeris path and sidereal mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be35e8f310832b985314eba3e62680