### PR TITLE
Truncate seconds in lonToSignDeg to match AstroSage

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -14,9 +14,9 @@ swe.ready.then(() => {
 // Signs are numbered 1–12 (1 = Aries, 12 = Pisces).
 function lonToSignDeg(longitude) {
   const norm = ((longitude % 360) + 360) % 360;
-  // AstroSage rounds seconds and carries overflows up through minutes and
-  // degrees, wrapping at sign boundaries.
-  let totalSeconds = Math.round(norm * 3600) % (360 * 3600);
+  // AstroSage truncates fractional seconds rather than rounding. Discard any
+  // fractional component without carrying overflows to minutes or degrees.
+  let totalSeconds = Math.floor(norm * 3600) % (360 * 3600);
   const sign = Math.floor(totalSeconds / (30 * 3600)) + 1; // 1..12
   const deg = Math.floor((totalSeconds % (30 * 3600)) / 3600);
   const min = Math.floor((totalSeconds % 3600) / 60);

--- a/tests/lon-to-sign-deg.test.js
+++ b/tests/lon-to-sign-deg.test.js
@@ -5,35 +5,35 @@ async function getFn() {
   return (await import('../src/lib/ephemeris.js')).lonToSignDeg;
 }
 
-test('lonToSignDeg rounds fractional seconds per AstroSage', async () => {
+test('lonToSignDeg truncates fractional seconds per AstroSage', async () => {
   const lonToSignDeg = await getFn();
   const lon = 14 + 46 / 60 + 57.99 / 3600;
   assert.deepStrictEqual(lonToSignDeg(lon), {
     sign: 1,
     deg: 14,
     min: 46,
-    sec: 58,
+    sec: 57,
   });
 });
 
-test('lonToSignDeg rounds up at sign boundary', async () => {
+test('lonToSignDeg truncates near sign boundary', async () => {
   const lonToSignDeg = await getFn();
   const lon = 29 + 59 / 60 + 59.99 / 3600;
   assert.deepStrictEqual(lonToSignDeg(lon), {
-    sign: 2,
-    deg: 0,
-    min: 0,
-    sec: 0,
+    sign: 1,
+    deg: 29,
+    min: 59,
+    sec: 59,
   });
 });
 
-test('lonToSignDeg normalizes and rounds negative longitudes', async () => {
+test('lonToSignDeg normalizes and truncates negative longitudes', async () => {
   const lonToSignDeg = await getFn();
   const lon = -(0.5 / 3600); // -0°0′0.5″ -> 359°59′59.5″
   assert.deepStrictEqual(lonToSignDeg(lon), {
-    sign: 1,
-    deg: 0,
-    min: 0,
-    sec: 0,
+    sign: 12,
+    deg: 29,
+    min: 59,
+    sec: 59,
   });
 });


### PR DESCRIPTION
## Summary
- truncate fractional seconds in `lonToSignDeg` to mirror AstroSage output
- update longitude tests to expect truncated values and no sign overflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be3ef48ad4832b807922d5cf5f120e