### PR TITLE
Align rounding and time truncation with AstroSage

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -17,7 +17,9 @@ function lonToSignDeg(longitude) {
   // AstroSage rounds fractional seconds, carrying any overflow into minutes,
   // degrees, and sign boundaries. Convert the longitude to total arcseconds
   // and round to the nearest second before decomposing.
-  let totalSeconds = Math.round(norm * 3600) % (360 * 3600);
+  // Add a tiny epsilon before rounding to avoid floating-point edge cases
+  // around half-second values (e.g., 59.5" being represented as 59.499999").
+  let totalSeconds = Math.round(norm * 3600 + 1e-9) % (360 * 3600);
   const sign = Math.floor(totalSeconds / (30 * 3600)) + 1; // 1..12
   const deg = Math.floor((totalSeconds % (30 * 3600)) / 3600);
   const min = Math.floor((totalSeconds % 3600) / 60);

--- a/src/lib/timezone.js
+++ b/src/lib/timezone.js
@@ -72,6 +72,9 @@ export function toUTC({ datetime, zone }) {
       DateTimeObj = req('luxon').DateTime;
     }
   }
-  const dt = DateTimeObj.fromISO(datetime, { zone });
+  // AstroSage truncates timestamps to whole seconds before converting to UT.
+  const dt = DateTimeObj.fromISO(datetime, { zone })
+    .startOf('second')
+    .toUTC();
   return dt.toJSDate();
 }

--- a/tests/lon-to-sign-deg.test.js
+++ b/tests/lon-to-sign-deg.test.js
@@ -7,7 +7,7 @@ async function getFn() {
 
 test('lonToSignDeg rounds fractional seconds per AstroSage', async () => {
   const lonToSignDeg = await getFn();
-  const lon = 14 + 46 / 60 + 57.99 / 3600;
+  const lon = 14 + 46 / 60 + 57.5 / 3600;
   assert.deepStrictEqual(lonToSignDeg(lon), {
     sign: 1,
     deg: 14,
@@ -16,14 +16,25 @@ test('lonToSignDeg rounds fractional seconds per AstroSage', async () => {
   });
 });
 
-test('lonToSignDeg rounds near sign boundary', async () => {
+test('lonToSignDeg rounds up exactly at half-second near sign boundary', async () => {
   const lonToSignDeg = await getFn();
-  const lon = 29 + 59 / 60 + 59.99 / 3600;
+  const lon = 29 + 59 / 60 + 59.5 / 3600;
   assert.deepStrictEqual(lonToSignDeg(lon), {
     sign: 2,
     deg: 0,
     min: 0,
     sec: 0,
+  });
+});
+
+test('lonToSignDeg does not round up when below half-second near sign boundary', async () => {
+  const lonToSignDeg = await getFn();
+  const lon = 29 + 59 / 60 + 59.49 / 3600;
+  assert.deepStrictEqual(lonToSignDeg(lon), {
+    sign: 1,
+    deg: 29,
+    min: 59,
+    sec: 59,
   });
 });
 

--- a/tests/to-utc.test.js
+++ b/tests/to-utc.test.js
@@ -1,0 +1,16 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import { DateTime } from 'luxon';
+
+test('toUTC drops sub-second fragments before converting', async () => {
+  // Provide DateTime globally so timezone.js can import it without require.
+  global.DateTime = DateTime;
+  const { toUTC } = await import('../src/lib/timezone.js');
+  const date = toUTC({
+    datetime: '2024-05-15T12:34:56.789',
+    zone: 'Asia/Kolkata',
+  });
+  assert.strictEqual(date.getUTCMilliseconds(), 0);
+  assert.strictEqual(date.toISOString(), '2024-05-15T07:04:56.000Z');
+  delete global.DateTime;
+});


### PR DESCRIPTION
## Summary
- Ensure longitude-to-sign conversion rounds fractional seconds like AstroSage, including edge cases at half-second boundaries
- Truncate sub-second fragments before UTC conversion to match AstroSage timestamps
- Add tests for longitude rounding near sign boundaries and for UTC truncation

## Testing
- `npm test tests/lon-to-sign-deg.test.js tests/to-utc.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68be4d7a0924832ba4a0602bc1646017