### PR TITLE
Align lonToSignDeg with AstroSage rounding semantics

### DIFF
--- a/tests/lon-to-sign-deg.test.js
+++ b/tests/lon-to-sign-deg.test.js
@@ -48,3 +48,14 @@ test('lonToSignDeg normalizes and rounds negative longitudes', async () => {
     sec: 0,
   });
 });
+
+test('lonToSignDeg carries overflow across 360° when rounding', async () => {
+  const lonToSignDeg = await getFn();
+  const lon = 359 + 59 / 60 + 59.5 / 3600;
+  assert.deepStrictEqual(lonToSignDeg(lon), {
+    sign: 1,
+    deg: 0,
+    min: 0,
+    sec: 0,
+  });
+});


### PR DESCRIPTION
## Summary
- Rework `lonToSignDeg` to mimic AstroSage rounding, carrying overflow from seconds through minutes, degrees, and sign.
- Expand unit tests for longitude conversion to cover 360° rollover.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be53d2d444832b847d3827de8a5685