### PR TITLE
feat: align helpers with AstroSage truncation

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -17,9 +17,9 @@ function lonToSignDeg(longitude) {
   let norm = ((longitude % 360) + 360) % 360;
 
   // Convert the normalised longitude to total arcseconds. AstroSage truncates
-  // fractional arcseconds rather than rounding, so use integer math to avoid
-  // floating point quirks.
-  let totalSec = Math.floor(norm * 3600 + 1e-9);
+  // fractional arcseconds instead of rounding, so drop any fraction with
+  // `Math.trunc` to mirror their behaviour exactly.
+  let totalSec = Math.trunc(norm * 3600);
   totalSec = ((totalSec % (360 * 3600)) + 360 * 3600) % (360 * 3600);
 
   const sign = Math.floor(totalSec / (30 * 3600)) + 1; // 1..12
@@ -37,7 +37,7 @@ function lonToSignDeg(longitude) {
 function toUTC({ datetime, zone }) {
   // AstroSage truncates timestamps to whole seconds before converting to UT.
   const dt = DateTime.fromISO(datetime, { zone })
-    .set({ millisecond: 0 })
+    .startOf('second')
     .toUTC();
   return dt.toJSDate();
 }

--- a/src/lib/timezone.js
+++ b/src/lib/timezone.js
@@ -74,7 +74,7 @@ export function toUTC({ datetime, zone }) {
   }
   // AstroSage truncates timestamps to whole seconds before converting to UT.
   const dt = DateTimeObj.fromISO(datetime, { zone })
-    .set({ millisecond: 0 })
+    .startOf('second')
     .toUTC();
   return dt.toJSDate();
 }

--- a/tests/lon-to-sign-deg.test.js
+++ b/tests/lon-to-sign-deg.test.js
@@ -16,6 +16,17 @@ test('lonToSignDeg truncates fractional seconds per AstroSage', async () => {
   });
 });
 
+test('lonToSignDeg does not round up near sign change', async () => {
+  const lonToSignDeg = await getFn();
+  const lon = 29 + 59 / 60 + 59.9999 / 3600;
+  assert.deepStrictEqual(lonToSignDeg(lon), {
+    sign: 1,
+    deg: 29,
+    min: 59,
+    sec: 59,
+  });
+});
+
 test('lonToSignDeg truncates near sign boundary without overflow', async () => {
   const lonToSignDeg = await getFn();
   const lon = 29 + 59 / 60 + 59.9 / 3600;

--- a/tests/to-utc.test.js
+++ b/tests/to-utc.test.js
@@ -9,3 +9,13 @@ test('toUTC drops sub-second fragments before converting', async () => {
   assert.strictEqual(date.getUTCMilliseconds(), 0);
   assert.strictEqual(date.toISOString(), '2024-05-15T07:04:56.000Z');
 });
+
+test('toUTC truncates without overflowing to next minute', async () => {
+  const { toUTC } = await import('../src/lib/ephemeris.js');
+  const date = toUTC({
+    datetime: '2024-05-15T12:34:59.999',
+    zone: 'Asia/Kolkata',
+  });
+  assert.strictEqual(date.getUTCMilliseconds(), 0);
+  assert.strictEqual(date.toISOString(), '2024-05-15T07:04:59.000Z');
+});


### PR DESCRIPTION
## Summary
- ensure lonToSignDeg drops fractional arcseconds using `Math.trunc`
- trim sub-second fragments with `startOf('second')` when converting to UTC
- add edge-case tests around sign changes and minute boundaries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be884da150832bb2e1cb9f199ee4e2