### PR TITLE
test: cover toUTC negative offset truncation

### DIFF
--- a/tests/to-utc.test.js
+++ b/tests/to-utc.test.js
@@ -19,3 +19,13 @@ test('toUTC truncates without overflowing to next minute', async () => {
   assert.strictEqual(date.getUTCMilliseconds(), 0);
   assert.strictEqual(date.toISOString(), '2024-05-15T07:04:59.000Z');
 });
+
+test('toUTC truncates before converting across negative offsets', async () => {
+  const { toUTC } = await import('../src/lib/ephemeris.js');
+  const date = toUTC({
+    datetime: '2024-05-15T00:00:00.999',
+    zone: 'America/New_York',
+  });
+  assert.strictEqual(date.getUTCMilliseconds(), 0);
+  assert.strictEqual(date.toISOString(), '2024-05-15T04:00:00.000Z');
+});


### PR DESCRIPTION
## Summary
- verify `toUTC` truncates sub-second time before UT conversion even with negative offsets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68be8d2b3298832b91a94ed15eabe53f