### PR TITLE
refactor: ensure lonToSignDeg truncation matches AstroSage

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -22,13 +22,14 @@ function lonToSignDeg(longitude) {
   let totalSec = Math.trunc(norm * 3600);
   totalSec = ((totalSec % (360 * 3600)) + 360 * 3600) % (360 * 3600);
 
-  const sign = Math.floor(totalSec / (30 * 3600)) + 1; // 1..12
+  // Break the total seconds down, truncating at each step to match AstroSage.
+  const sign = Math.trunc(totalSec / (30 * 3600)) + 1; // 1..12
   totalSec %= 30 * 3600;
 
-  const deg = Math.floor(totalSec / 3600);
+  const deg = Math.trunc(totalSec / 3600);
   totalSec %= 3600;
 
-  const min = Math.floor(totalSec / 60);
+  const min = Math.trunc(totalSec / 60);
   const sec = totalSec % 60;
 
   return { sign, deg, min, sec };

--- a/tests/lon-to-sign-deg.test.js
+++ b/tests/lon-to-sign-deg.test.js
@@ -16,6 +16,17 @@ test('lonToSignDeg truncates fractional seconds per AstroSage', async () => {
   });
 });
 
+test('lonToSignDeg normalizes longitudes greater than 360°', async () => {
+  const lonToSignDeg = await getFn();
+  const base = 14 + 46 / 60 + 57.5 / 3600;
+  assert.deepStrictEqual(lonToSignDeg(base + 360), {
+    sign: 1,
+    deg: 14,
+    min: 46,
+    sec: 57,
+  });
+});
+
 test('lonToSignDeg does not round up near sign change', async () => {
   const lonToSignDeg = await getFn();
   const lon = 29 + 59 / 60 + 59.9999 / 3600;


### PR DESCRIPTION
## Summary
- truncate sign, degree, and minute breakdowns in `lonToSignDeg`
- add normalization test for longitudes over 360°

## Testing
- `npm test tests/lon-to-sign-deg.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68be92b11000832b8c5f04b6a6b91837