### PR TITLE
Align time truncation with AstroSage scheme

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -68,11 +68,12 @@ async function compute_positions(
   } catch {}
 
   const date = toUTC({ datetime, zone: tz });
+  // `toUTC` already truncates to whole seconds, so mirror AstroSage by
+  // ignoring any sub-second fragments when calculating UT.
   const ut =
     date.getUTCHours() +
     date.getUTCMinutes() / 60 +
-    date.getUTCSeconds() / 3600 +
-    date.getUTCMilliseconds() / 3600000;
+    date.getUTCSeconds() / 3600;
   const jd = sweInst.swe_julday(
     date.getUTCFullYear(),
     date.getUTCMonth() + 1,

--- a/tests/to-utc.test.js
+++ b/tests/to-utc.test.js
@@ -23,9 +23,19 @@ test('toUTC truncates without overflowing to next minute', async () => {
 test('toUTC truncates before converting across negative offsets', async () => {
   const { toUTC } = await import('../src/lib/ephemeris.js');
   const date = toUTC({
-    datetime: '2024-05-15T00:00:00.999',
+    datetime: '2024-05-15T23:59:59.999',
     zone: 'America/New_York',
   });
   assert.strictEqual(date.getUTCMilliseconds(), 0);
-  assert.strictEqual(date.toISOString(), '2024-05-15T04:00:00.000Z');
+  assert.strictEqual(date.toISOString(), '2024-05-16T03:59:59.000Z');
+});
+
+test('toUTC truncates before converting across positive offsets', async () => {
+  const { toUTC } = await import('../src/lib/ephemeris.js');
+  const date = toUTC({
+    datetime: '2024-05-15T00:00:00.999',
+    zone: 'Asia/Kolkata',
+  });
+  assert.strictEqual(date.getUTCMilliseconds(), 0);
+  assert.strictEqual(date.toISOString(), '2024-05-14T18:30:00.000Z');
 });


### PR DESCRIPTION
## Summary
- Ignore sub-second data when calculating UT so AstroSage-style truncation carries through position computations
- Add timezone boundary tests to ensure toUTC mirrors AstroSage across positive and negative offsets

## Testing
- `npm test tests/lon-to-sign-deg.test.js tests/to-utc.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68beaa39e504832ba37af99f0ea63de8