### PR TITLE
Handle ISO timestamps with embedded offsets

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -37,9 +37,11 @@ function lonToSignDeg(longitude) {
 
 function toUTC({ datetime, zone }) {
   // AstroSage truncates timestamps to whole seconds before converting to UT.
-  const dt = DateTime.fromISO(datetime, { zone })
-    .startOf('second')
-    .toUTC();
+  // If no explicit zone is provided, respect any offset embedded in the ISO
+  // timestamp. This mirrors typical usage where callers pass
+  // `YYYY-MM-DDTHH:mm+HH:mm` without a separate time zone argument.
+  const opts = zone ? { zone } : { setZone: true };
+  const dt = DateTime.fromISO(datetime, opts).startOf('second').toUTC();
   return dt.toJSDate();
 }
 

--- a/tests/pushkar-mishra-regression.test.js
+++ b/tests/pushkar-mishra-regression.test.js
@@ -135,8 +135,7 @@ const LON_TOLERANCE = 0.0003; // degrees (~1 arcsecond)
 test('Pushkar Mishra positions regression', async () => {
   const { compute_positions } = await import('../src/lib/ephemeris.js');
   const res = await compute_positions({
-    datetime: '1982-12-01T03:50',
-    tz: 'Asia/Kolkata',
+    datetime: '1982-12-01T03:50+05:30',
     lat: 26.152,
     lon: 85.897,
     nodeType: 'mean',


### PR DESCRIPTION
## Summary
- allow `toUTC` to use offsets inside ISO timestamps when no zone is supplied
- update Pushkar Mishra regression test to pass timestamp with `+05:30` offset directly

## Testing
- `npm test tests/pushkar-mishra-regression.test.js`
- `npm test tests/to-utc.test.js`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bebee50aa4832bb413ecce0b3e249e