### PR TITLE
Handle AstroSage style rounding for longitudes

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -17,8 +17,10 @@ function lonToSignDeg(longitude) {
   let norm = ((longitude % 360) + 360) % 360;
 
   // Convert the normalised longitude to total arcseconds and round to the
-  // nearest whole arcsecond. AstroSage rounds instead of truncating, so use
-  // `Math.round` to mirror their behaviour exactly.
+  // nearest whole arcsecond. AstroSage uses half-up rounding here, so a
+  // fractional part of 0.5 seconds or greater rounds up to the next second.
+  // A tiny epsilon compensates for floating-point noise that could otherwise
+  // push values like 57.5″ slightly below the 0.5″ threshold.
   let totalSec = Math.round(norm * 3600 + 1e-9);
   totalSec = ((totalSec % (360 * 3600)) + 360 * 3600) % (360 * 3600);
 

--- a/tests/lon-to-sign-deg.test.js
+++ b/tests/lon-to-sign-deg.test.js
@@ -60,6 +60,17 @@ test('lonToSignDeg rounds and normalizes negative longitudes', async () => {
   });
 });
 
+test('lonToSignDeg rounds negative longitudes across sign boundary', async () => {
+  const lonToSignDeg = await getFn();
+  const lon = -(29 + 59 / 60 + 59.5 / 3600); // -> 330°0′0.5″ -> 330°0′1″
+  assert.deepStrictEqual(lonToSignDeg(lon), {
+    sign: 12,
+    deg: 0,
+    min: 0,
+    sec: 1,
+  });
+});
+
 test('lonToSignDeg rounds near 360° to Aries', async () => {
   const lonToSignDeg = await getFn();
   const lon = 359 + 59 / 60 + 59.9 / 3600;


### PR DESCRIPTION
## Summary
- Round normalised longitudes to the nearest arcsecond using half-up semantics and an epsilon to mirror AstroSage
- Extend `lonToSignDeg` unit tests, including a case for negative values crossing sign boundaries

## Testing
- `npm test tests/lon-to-sign-deg.test.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bec0ecfbb0832ba966dfe4f0efb33c