### PR TITLE
Align longitude rounding with AstroSage

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -21,7 +21,9 @@ function lonToSignDeg(longitude) {
   // fractional part of 0.5 seconds or greater rounds up to the next second.
   // A tiny epsilon compensates for floating-point noise that could otherwise
   // push values like 57.5″ slightly below the 0.5″ threshold.
-  let totalSec = Math.round(norm * 3600 + 1e-9);
+  // Use explicit half-up rounding via `Math.floor(value + 0.5)` to mirror the
+  // behaviour observed on AstroSage.
+  let totalSec = Math.floor(norm * 3600 + 0.5 + 1e-9);
   totalSec = ((totalSec % (360 * 3600)) + 360 * 3600) % (360 * 3600);
 
   // Break the total seconds down using integer division.

--- a/tests/lon-to-sign-deg.test.js
+++ b/tests/lon-to-sign-deg.test.js
@@ -16,6 +16,14 @@ test('lonToSignDeg rounds fractional seconds per AstroSage', async () => {
   });
 });
 
+test('lonToSignDeg handles floating-point noise at 0.5″', async () => {
+  const lonToSignDeg = await getFn();
+  const up = 14 + 46 / 60 + (57.5 + 1e-6) / 3600;
+  const down = 14 + 46 / 60 + (57.5 - 1e-6) / 3600;
+  assert.strictEqual(lonToSignDeg(up).sec, 58);
+  assert.strictEqual(lonToSignDeg(down).sec, 57);
+});
+
 test('lonToSignDeg normalizes longitudes greater than 360°', async () => {
   const lonToSignDeg = await getFn();
   const base = 14 + 46 / 60 + 57.5 / 3600;


### PR DESCRIPTION
## Summary
- mirror AstroSage's half-up longitude rounding by flooring the arcseconds after adding 0.5
- cover floating-point edge cases in `lonToSignDeg` unit tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68becd6c41cc832b9276a81b1699507a