### PR TITLE
feat: implement banker's rounding for longitude

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -17,13 +17,21 @@ function lonToSignDeg(longitude) {
   let norm = ((longitude % 360) + 360) % 360;
 
   // Convert the normalised longitude to total arcseconds and round to the
-  // nearest whole arcsecond. AstroSage uses half-up rounding here, so a
-  // fractional part of 0.5 seconds or greater rounds up to the next second.
-  // A tiny epsilon compensates for floating-point noise that could otherwise
-  // push values like 57.5″ slightly below the 0.5″ threshold.
-  // Use explicit half-up rounding via `Math.floor(value + 0.5)` to mirror the
-  // behaviour observed on AstroSage.
-  let totalSec = Math.floor(norm * 3600 + 0.5 + 1e-9);
+  // nearest whole arcsecond. Investigations of AstroSage output show that it
+  // uses *banker's rounding* (round half to even) when converting fractional
+  // seconds. A tiny epsilon compensates for floating-point noise that could
+  // otherwise push values like 57.5″ slightly below the 0.5″ threshold.
+  let totalSec = norm * 3600;
+  const floor = Math.floor(totalSec);
+  const frac = totalSec - floor;
+  if (frac > 0.5 + 1e-9) {
+    totalSec = floor + 1;
+  } else if (frac < 0.5 - 1e-9) {
+    totalSec = floor;
+  } else {
+    // Exactly halfway (within epsilon): round to the nearest even integer.
+    totalSec = floor + (floor % 2);
+  }
   totalSec = ((totalSec % (360 * 3600)) + 360 * 3600) % (360 * 3600);
 
   // Break the total seconds down using integer division.

--- a/tests/lon-to-sign-deg.test.js
+++ b/tests/lon-to-sign-deg.test.js
@@ -16,6 +16,17 @@ test('lonToSignDeg rounds fractional seconds per AstroSage', async () => {
   });
 });
 
+test("lonToSignDeg uses banker's rounding for 0.5″", async () => {
+  const lonToSignDeg = await getFn();
+  const lon = 14 + 46 / 60 + 58.5 / 3600;
+  assert.deepStrictEqual(lonToSignDeg(lon), {
+    sign: 1,
+    deg: 14,
+    min: 46,
+    sec: 58,
+  });
+});
+
 test('lonToSignDeg handles floating-point noise at 0.5″', async () => {
   const lonToSignDeg = await getFn();
   const up = 14 + 46 / 60 + (57.5 + 1e-6) / 3600;
@@ -70,12 +81,12 @@ test('lonToSignDeg rounds and normalizes negative longitudes', async () => {
 
 test('lonToSignDeg rounds negative longitudes across sign boundary', async () => {
   const lonToSignDeg = await getFn();
-  const lon = -(29 + 59 / 60 + 59.5 / 3600); // -> 330°0′0.5″ -> 330°0′1″
+  const lon = -(29 + 59 / 60 + 59.5 / 3600); // -> 330°0′0.5″ -> 330°0′0″
   assert.deepStrictEqual(lonToSignDeg(lon), {
     sign: 12,
     deg: 0,
     min: 0,
-    sec: 1,
+    sec: 0,
   });
 });
 


### PR DESCRIPTION
## Summary
- refine `lonToSignDeg` to use banker's rounding (round half to even)
- expand tests for `lonToSignDeg` including tie-to-even and negative boundary cases

## Testing
- `npm test --silent`
- `node --test tests/lon-to-sign-deg.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bed3be8334832b937ec68af876900f