### PR TITLE
Adjust lonToSignDeg rounding to match AstroSage

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -17,21 +17,11 @@ function lonToSignDeg(longitude) {
   let norm = ((longitude % 360) + 360) % 360;
 
   // Convert the normalised longitude to total arcseconds and round to the
-  // nearest whole arcsecond. Investigations of AstroSage output show that it
-  // uses *banker's rounding* (round half to even) when converting fractional
-  // seconds. A tiny epsilon compensates for floating-point noise that could
-  // otherwise push values like 57.5″ slightly below the 0.5″ threshold.
-  let totalSec = norm * 3600;
-  const floor = Math.floor(totalSec);
-  const frac = totalSec - floor;
-  if (frac > 0.5 + 1e-9) {
-    totalSec = floor + 1;
-  } else if (frac < 0.5 - 1e-9) {
-    totalSec = floor;
-  } else {
-    // Exactly halfway (within epsilon): round to the nearest even integer.
-    totalSec = floor + (floor % 2);
-  }
+  // nearest whole arcsecond. AstroSage rounds halves upward ("half away from
+  // zero"), so 0.5″ becomes 1″. A tiny epsilon compensates for floating-point
+  // noise that could otherwise push values like 57.5″ slightly below the 0.5″
+  // threshold.
+  let totalSec = Math.round(norm * 3600 + 1e-9);
   totalSec = ((totalSec % (360 * 3600)) + 360 * 3600) % (360 * 3600);
 
   // Break the total seconds down using integer division.

--- a/tests/lon-to-sign-deg.test.js
+++ b/tests/lon-to-sign-deg.test.js
@@ -16,14 +16,14 @@ test('lonToSignDeg rounds fractional seconds per AstroSage', async () => {
   });
 });
 
-test("lonToSignDeg uses banker's rounding for 0.5″", async () => {
+test('lonToSignDeg rounds 0.5″ upward', async () => {
   const lonToSignDeg = await getFn();
   const lon = 14 + 46 / 60 + 58.5 / 3600;
   assert.deepStrictEqual(lonToSignDeg(lon), {
     sign: 1,
     deg: 14,
     min: 46,
-    sec: 58,
+    sec: 59,
   });
 });
 
@@ -81,12 +81,12 @@ test('lonToSignDeg rounds and normalizes negative longitudes', async () => {
 
 test('lonToSignDeg rounds negative longitudes across sign boundary', async () => {
   const lonToSignDeg = await getFn();
-  const lon = -(29 + 59 / 60 + 59.5 / 3600); // -> 330°0′0.5″ -> 330°0′0″
+  const lon = -(29 + 59 / 60 + 59.5 / 3600); // -> 330°0′0.5″ -> 330°0′1″
   assert.deepStrictEqual(lonToSignDeg(lon), {
     sign: 12,
     deg: 0,
     min: 0,
-    sec: 0,
+    sec: 1,
   });
 });
 


### PR DESCRIPTION
## Summary
- round longitude seconds using half-up instead of banker's rounding
- update lon-to-sign-degree tests for half-up behavior, including negative longitudes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bedaadb3a0832ba0032c33280c2b30