### PR TITLE
Align rounding and UTC conversion with AstroSage

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -18,10 +18,11 @@ function lonToSignDeg(longitude) {
 
   // Convert the normalised longitude to total arcseconds and round to the
   // nearest whole arcsecond. AstroSage rounds halves upward ("half away from
-  // zero"), so 0.5″ becomes 1″. A tiny epsilon compensates for floating-point
-  // noise that could otherwise push values like 57.5″ slightly below the 0.5″
-  // threshold.
-  let totalSec = Math.round(norm * 3600 + 1e-9);
+  // zero"), so 0.5″ becomes 1″. Performing the rounding manually with
+  // `Math.trunc(x + 0.5)` makes the intent explicit. A tiny epsilon compensates
+  // for floating-point noise that could otherwise push values like 57.5″
+  // slightly below the 0.5″ threshold.
+  let totalSec = Math.trunc(norm * 3600 + 0.5 + 1e-9);
   totalSec = ((totalSec % (360 * 3600)) + 360 * 3600) % (360 * 3600);
 
   // Break the total seconds down using integer division.

--- a/tests/lon-to-sign-deg.test.js
+++ b/tests/lon-to-sign-deg.test.js
@@ -46,6 +46,17 @@ test('lonToSignDeg normalizes longitudes greater than 360°', async () => {
   });
 });
 
+test('lonToSignDeg normalizes longitudes less than -360°', async () => {
+  const lonToSignDeg = await getFn();
+  const base = 14 + 46 / 60 + 57.5 / 3600;
+  assert.deepStrictEqual(lonToSignDeg(base - 720), {
+    sign: 1,
+    deg: 14,
+    min: 46,
+    sec: 58,
+  });
+});
+
 test('lonToSignDeg rounds down just below sign boundary', async () => {
   const lonToSignDeg = await getFn();
   const lon = 29 + 59 / 60 + 59.4 / 3600;

--- a/tests/to-utc.test.js
+++ b/tests/to-utc.test.js
@@ -1,5 +1,11 @@
 import assert from 'node:assert';
 import test from 'node:test';
+test('toUTC uses offset in ISO timestamp when no zone given', async () => {
+  const { toUTC } = await import('../src/lib/ephemeris.js');
+  const date = toUTC({ datetime: '2024-05-15T12:34:56.789+05:30' });
+  assert.strictEqual(date.getUTCMilliseconds(), 0);
+  assert.strictEqual(date.toISOString(), '2024-05-15T07:04:56.000Z');
+});
 test('toUTC drops sub-second fragments before converting', async () => {
   const { toUTC } = await import('../src/lib/ephemeris.js');
   const date = toUTC({


### PR DESCRIPTION
## Summary
- Explicit half-up rounding for longitudes with floating point tolerance
- UTC helper respects ISO offsets and trims sub-seconds like AstroSage
- Extended tests for extreme longitudes and offset-based UTC conversion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68befe0c889c832b94b714363e1fc1da