### PR TITLE
Test half-second rounding and truncation

### DIFF
--- a/tests/lon-to-sign-deg.test.js
+++ b/tests/lon-to-sign-deg.test.js
@@ -27,6 +27,17 @@ test('lonToSignDeg rounds 0.5″ upward', async () => {
   });
 });
 
+test('lonToSignDeg rounds fractions below 0.5″ downward', async () => {
+  const lonToSignDeg = await getFn();
+  const lon = 14 + 46 / 60 + 57.4 / 3600;
+  assert.deepStrictEqual(lonToSignDeg(lon), {
+    sign: 1,
+    deg: 14,
+    min: 46,
+    sec: 57,
+  });
+});
+
 test('lonToSignDeg handles floating-point noise at 0.5″', async () => {
   const lonToSignDeg = await getFn();
   const up = 14 + 46 / 60 + (57.5 + 1e-6) / 3600;

--- a/tests/to-utc.test.js
+++ b/tests/to-utc.test.js
@@ -16,6 +16,16 @@ test('toUTC drops sub-second fragments before converting', async () => {
   assert.strictEqual(date.toISOString(), '2024-05-15T07:04:56.000Z');
 });
 
+test('toUTC truncates half-second values', async () => {
+  const { toUTC } = await import('../src/lib/ephemeris.js');
+  const date = toUTC({
+    datetime: '2024-05-15T12:34:56.500',
+    zone: 'Asia/Kolkata',
+  });
+  assert.strictEqual(date.getUTCMilliseconds(), 0);
+  assert.strictEqual(date.toISOString(), '2024-05-15T07:04:56.000Z');
+});
+
 test('toUTC truncates without overflowing to next minute', async () => {
   const { toUTC } = await import('../src/lib/ephemeris.js');
   const date = toUTC({


### PR DESCRIPTION
## Summary
- Add unit test confirming `lonToSignDeg` drops fractions <0.5" while rounding halves upward
- Cover `toUTC` truncation of half-second timestamps to match AstroSage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf1ee7c070832b84e6064b8fea7334