### PR TITLE
refactor: clarify longitude rounding

### DIFF
--- a/src/lib/ephemeris.js
+++ b/src/lib/ephemeris.js
@@ -18,21 +18,21 @@ function lonToSignDeg(longitude) {
 
   // Convert the normalised longitude to total arcseconds and round to the
   // nearest whole arcsecond. AstroSage rounds halves upward ("half away from
-  // zero"), so 0.5″ becomes 1″. Performing the rounding manually with
-  // `Math.trunc(x + 0.5)` makes the intent explicit. A tiny epsilon compensates
-  // for floating-point noise that could otherwise push values like 57.5″
-  // slightly below the 0.5″ threshold.
-  let totalSec = Math.trunc(norm * 3600 + 0.5 + 1e-9);
+  // zero"), so 0.5″ becomes 1″. `Math.round` mirrors this behaviour for
+  // positive numbers once the longitude has been normalised. A tiny epsilon
+  // compensates for floating-point noise that could otherwise push values like
+  // 57.5″ slightly below the 0.5″ threshold.
+  let totalSec = Math.round(norm * 3600 + 1e-9);
   totalSec = ((totalSec % (360 * 3600)) + 360 * 3600) % (360 * 3600);
 
   // Break the total seconds down using integer division.
-  const sign = Math.trunc(totalSec / (30 * 3600)) + 1; // 1..12
+  const sign = Math.floor(totalSec / (30 * 3600)) + 1; // 1..12
   totalSec %= 30 * 3600;
 
-  const deg = Math.trunc(totalSec / 3600);
+  const deg = Math.floor(totalSec / 3600);
   totalSec %= 3600;
 
-  const min = Math.trunc(totalSec / 60);
+  const min = Math.floor(totalSec / 60);
   const sec = totalSec % 60;
 
   return { sign, deg, min, sec };

--- a/tests/lon-to-sign-deg.test.js
+++ b/tests/lon-to-sign-deg.test.js
@@ -68,6 +68,17 @@ test('lonToSignDeg normalizes longitudes less than -360°', async () => {
   });
 });
 
+test('lonToSignDeg rounds up across minute boundary', async () => {
+  const lonToSignDeg = await getFn();
+  const lon = 14 + 59 / 60 + 59.5 / 3600;
+  assert.deepStrictEqual(lonToSignDeg(lon), {
+    sign: 1,
+    deg: 15,
+    min: 0,
+    sec: 0,
+  });
+});
+
 test('lonToSignDeg rounds down just below sign boundary', async () => {
   const lonToSignDeg = await getFn();
   const lon = 29 + 59 / 60 + 59.4 / 3600;


### PR DESCRIPTION
## Summary
- refine `lonToSignDeg` to use `Math.round` and an epsilon for AstroSage-style rounding
- extend tests to cover rounding across minute boundaries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf79b7778c832b91c3cbab934bc69f