### PR TITLE
refactor: load swisseph asynchronously

### DIFF
--- a/server/index.cjs
+++ b/server/index.cjs
@@ -76,18 +76,15 @@ async function startServer() {
     swisseph.swe_set_ephe_path(ephemerisPath);
     swisseph.swe_set_sid_mode(swisseph.SE_SIDM_LAHIRI, 0, 0);
     console.log('Swiss Ephemeris path configured successfully.');
-
-    // Start the server only after Swiss Ephemeris is configured and only if this
-    // file is executed directly.
-    if (require.main === module) {
-      app.listen(PORT, () => {
-        console.log(`Server listening on port ${PORT}`);
-      });
-    }
+    app.listen(PORT, () => {
+      console.log(`Server listening on port ${PORT}`);
+    });
   } catch (err) {
     console.error('Failed to configure Swiss Ephemeris:', err);
     process.exit(1);
   }
 }
-
-startServer();
+// Only start the server if this file is executed directly.
+if (require.main === module) {
+  startServer();
+}


### PR DESCRIPTION
## Summary
- load `swisseph` via dynamic `import()` and await readiness before configuration
- start server only after configuring Swiss Ephemeris

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf837b4064832b901ded13f60ff805