### PR TITLE
chore: enforce node 18 requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Earlier revisions used 0-based indices; tests and UI helpers now follow the
 
 ## Prerequisites
 
-- Node.js and npm
+- Node.js 18 or newer and npm
 
 ## Local Setup & Installation
 

--- a/check-node-version.js
+++ b/check-node-version.js
@@ -1,0 +1,6 @@
+const major = parseInt(process.versions.node.split('.')[0], 10);
+const required = 18;
+if (major < required) {
+  console.error(`Node.js ${required} or newer is required. You are using ${process.versions.node}.`);
+  process.exit(1);
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,12 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "scripts": {
+    "prestart": "node check-node-version.js",
+    "start": "node server/index.js",
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",


### PR DESCRIPTION
## Summary
- add engines field requiring Node.js 18+
- document Node.js 18 prerequisite
- add prestart check to warn when Node version is too low

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c05820d1dc832bb4c56127c724862a