### PR TITLE
Reorder houses clockwise

### DIFF
--- a/src/lib/astro.js
+++ b/src/lib/astro.js
@@ -110,20 +110,20 @@ function buildChartPaths(scale = 1) {
   ];
 
   // House polygons derived from chart geometry
-  // Order corresponds to houses 1–12 progressing anti-clockwise
+  // Order corresponds to houses 1–12 progressing clockwise
   const housePolygons = [
     [P1, MT, P3, O], // 1st house (top centre)
-    [TL, MT, P1], // 2nd
-    [ML, TL, P1], // 3rd
-    [ML, P1, O, P4], // 4th
-    [BL, ML, P4], // 5th
-    [MB, BL, P4], // 6th
+    [MT, TR, P3], // 2nd (top right)
+    [TR, MR, P3], // 3rd
+    [P3, MR, P2, O], // 4th
+    [MR, BR, P2], // 5th
+    [BR, MB, P2], // 6th
     [P2, MB, P4, O], // 7th
-    [BR, MB, P2], // 8th
-    [MR, BR, P2], // 9th
-    [P3, MR, P2, O], // 10th
-    [TR, MR, P3], // 11th
-    [MT, TR, P3], // 12th
+    [MB, BL, P4], // 8th
+    [BL, ML, P4], // 9th
+    [ML, P1, O, P4], // 10th
+    [ML, TL, P1], // 11th
+    [TL, MT, P1], // 12th (top left)
   ].map((poly) => poly.map(([x, y]) => [x * scale, y * scale]));
 
   return { outer, inner, diagonals, housePolygons };

--- a/tests/houses-order.test.js
+++ b/tests/houses-order.test.js
@@ -27,7 +27,7 @@ class Element {
 
 const doc = { createElementNS: (ns, tag) => new Element(tag) };
 
-test('houses and signs increase anti-clockwise from ascendant', async () => {
+test('houses and signs increase clockwise from ascendant', async () => {
   const signInHouse = [null];
   for (let h = 1; h <= 12; h++) signInHouse[h] = h;
   const data = { ascSign: 1, signInHouse, planets: [] };
@@ -58,6 +58,6 @@ test('houses and signs increase anti-clockwise from ascendant', async () => {
     const x2 = cx2 - 0.5;
     const y2 = 0.5 - cy2;
     const cross = x1 * y2 - y1 * x2;
-    assert.ok(cross > 0, `houses ${i + 1} -> ${((i + 2) > 12 ? 1 : i + 2)} not anti-clockwise`);
+    assert.ok(cross < 0, `houses ${i + 1} -> ${((i + 2) > 12 ? 1 : i + 2)} not clockwise`);
   }
 });


### PR DESCRIPTION
## Summary
- Reordered North Indian chart polygons to number houses clockwise with house 2 starting at the top right
- Updated orientation tests to expect clockwise progression

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0cfb68a40832bad2459eb30e10972