### PR TITLE
feat: add AstroSage nakshatra abbreviations

### DIFF
--- a/src/lib/nakshatra.js
+++ b/src/lib/nakshatra.js
@@ -28,8 +28,9 @@ const NAKSHATRA_NAMES = [
   'Revati',
 ];
 
-// Common four-letter abbreviations corresponding to the full names above.
-// These provide short but still recognisable labels for UI display.
+// AstroSage-style abbreviations corresponding to the full names above.
+// These match the labels used in AstroSage charts, offering familiar
+// short forms for users who prefer that formatting.
 const NAKSHATRA_ABBREVIATIONS = [
   'Aswi',
   'Bhar',
@@ -41,8 +42,8 @@ const NAKSHATRA_ABBREVIATIONS = [
   'Push',
   'Ashl',
   'Magh',
-  'PPhl',
-  'UPhl',
+  'PuPha',
+  'UtPha',
   'Hast',
   'Chit',
   'Swat',
@@ -50,13 +51,13 @@ const NAKSHATRA_ABBREVIATIONS = [
   'Anur',
   'Jyes',
   'Mula',
-  'PAsa',
-  'UAsa',
+  'PuSha',
+  'UtSha',
   'Shra',
   'Dhan',
   'Shat',
-  'PBha',
-  'UBha',
+  'PuBha',
+  'UtBha',
   'Reva',
 ];
 

--- a/src/lib/summary.js
+++ b/src/lib/summary.js
@@ -1,4 +1,5 @@
 import { SIGN_NAMES } from './astro.js';
+import { NAKSHATRA_NAME_TO_ABBR } from './nakshatra.js';
 
 const PLANET_ABBR = {
   sun: 'Su',
@@ -31,11 +32,15 @@ function formatDMS(p) {
   return `${d}°${String(m).padStart(2, '0')}′${String(s).padStart(2, '0')}″`;
 }
 
-export function summarizeChart(data) {
+export function summarizeChart(data, { useNakshatraAbbr = false } = {}) {
   const ascSignName = SIGN_NAMES[data.ascSign - 1];
   let ascendant = ascSignName;
   if (data.ascendant?.nakshatra && data.ascendant?.pada) {
-    ascendant += ` ${data.ascendant.nakshatra} ${data.ascendant.pada}`;
+    const nak = useNakshatraAbbr
+      ? NAKSHATRA_NAME_TO_ABBR[data.ascendant.nakshatra] ||
+        data.ascendant.nakshatra
+      : data.ascendant.nakshatra;
+    ascendant += ` ${nak} ${data.ascendant.pada}`;
   }
   const moon = data.planets.find((p) => p.name === 'moon');
   const moonSign = SIGN_NAMES[(moon?.sign ?? 1) - 1]; // 1-based sign numbers
@@ -51,7 +56,10 @@ export function summarizeChart(data) {
         const degStr = formatDMS(p);
         let extra = '';
         if (p.nakshatra && p.pada) {
-          extra = ` ${p.nakshatra} ${p.pada}`;
+          const nak = useNakshatraAbbr
+            ? NAKSHATRA_NAME_TO_ABBR[p.nakshatra] || p.nakshatra
+            : p.nakshatra;
+          extra = ` ${nak} ${p.pada}`;
         }
         const signName = SIGN_NAMES[(p.sign ?? 1) - 1];
         return `${signName} ${abbr} ${degStr}${extra}`;

--- a/tests/nakshatra-abbr.test.js
+++ b/tests/nakshatra-abbr.test.js
@@ -15,4 +15,6 @@ test('computePositions returns nakshatra abbreviations when requested', async ()
   assert.strictEqual(mercury.nakshatra, 'Jyes');
   const moon = data.planets.find((p) => p.name === 'moon');
   assert.strictEqual(moon.nakshatra, 'Rohi');
+  const mars = data.planets.find((p) => p.name === 'mars');
+  assert.strictEqual(mars.nakshatra, 'UtSha');
 });


### PR DESCRIPTION
## Summary
- update nakshatra abbreviations to AstroSage format (e.g. PuPha, UtSha)
- allow summary to render AstroSage abbreviations via option
- extend abbreviation test to cover UtSha mapping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c53c22adac832b91742ebeb6369cd6