### PR TITLE
Validate house and node options in API

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,15 +76,17 @@ accept these optional settings:
 
 - `sidMode` – numeric code passed to Swiss Ephemeris' `swe_set_sid_mode`.
   Defaults to `swe.SE_SIDM_LAHIRI` when omitted.
-- `houseSystem` – single-letter code for the desired house system passed to
-  `swe_houses_ex`. The default `'W'` uses whole-sign houses to match AstroSage's
+- `houseSystem` – single-letter code (`A`–`Y`) for the desired house system
+  passed to `swe_houses_ex`. Examples include `'W'` (whole sign, default), `'P'`
+  (Placidus), `'O'` (Porphyry), `'K'` (Koch), `'R'` (Regiomontanus), `'C'`
+  (Campanus), `'A'`/`'E'` (Equal), `'V'` (Vehlow), `'X'` (Meridian), `'G'`
+  (Gauquelin) and `'T'` (Topocentric). The default `'W'` matches AstroSage's
   Rāśi chart.
-- `nodeType` – `'true'` or `'mean'` to select whether lunar nodes are computed
-  using `SE_TRUE_NODE` or `SE_MEAN_NODE`. `'mean'` uses the smoothed average
-  position (AstroSage's default) while `'true'` includes the node's small
+- `nodeType` – `'mean'` or `'true'` to select whether lunar nodes are computed
+  using `SE_MEAN_NODE` (default, AstroSage's setting) or `SE_TRUE_NODE`. `'mean'`
+  uses the smoothed average position while `'true'` includes the node's small
   oscillation. For the reference Darbhanga chart both options place Rahu and
   Ketu in Gemini/Sagittarius, though the longitudes differ by about a degree.
-  The default is 'mean'.
 
 When these options are not provided the calculation assumes Lahiri ayanamsa,
 whole-sign houses and the mean lunar node, which mirrors AstroSage's

--- a/server/index.cjs
+++ b/server/index.cjs
@@ -19,6 +19,35 @@ if (!fs.existsSync(ephemerisPath)) {
 const app = express();
 const PORT = process.env.PORT || 3001;
 
+const VALID_NODE_TYPES = new Set(['mean', 'true']);
+const VALID_HOUSE_SYSTEMS = new Set([
+  'A',
+  'B',
+  'C',
+  'D',
+  'E',
+  'F',
+  'G',
+  'H',
+  'I',
+  'J',
+  'K',
+  'L',
+  'M',
+  'N',
+  'O',
+  'P',
+  'Q',
+  'R',
+  'S',
+  'T',
+  'U',
+  'V',
+  'W',
+  'X',
+  'Y',
+]);
+
 // --- API Endpoints ---
 
 let ephemerisModule;
@@ -30,7 +59,16 @@ async function getEphemeris() {
 }
 
 app.get('/api/positions', async (req, res) => {
-  const { datetime, tz, lat, lon, sidMode, nodeType, nakshatraAbbr } = req.query;
+  const {
+    datetime,
+    tz,
+    lat,
+    lon,
+    sidMode,
+    houseSystem,
+    nodeType,
+    nakshatraAbbr,
+  } = req.query;
   if (!datetime || !tz || !lat || !lon) {
     return res
       .status(400)
@@ -45,6 +83,14 @@ app.get('/api/positions', async (req, res) => {
     if (!Number.isFinite(lonNum)) {
       return res.status(400).json({ error: 'Invalid longitude parameter' });
     }
+    const node = nodeType ? nodeType.toLowerCase() : undefined;
+    if (nodeType && !VALID_NODE_TYPES.has(node)) {
+      return res.status(400).json({ error: 'Invalid nodeType parameter' });
+    }
+    const house = houseSystem ? houseSystem.toUpperCase() : undefined;
+    if (houseSystem && !VALID_HOUSE_SYSTEMS.has(house)) {
+      return res.status(400).json({ error: 'Invalid houseSystem parameter' });
+    }
     const { compute_positions } = await getEphemeris();
     const sidModeNum = sidMode ? parseInt(sidMode, 10) : undefined;
     const result = await compute_positions({
@@ -53,7 +99,8 @@ app.get('/api/positions', async (req, res) => {
       lat: latNum,
       lon: lonNum,
       sidMode: sidModeNum,
-      nodeType,
+      nodeType: node,
+      houseSystem: house,
       nakshatraAbbr: nakshatraAbbr === 'true' || nakshatraAbbr === '1',
     });
     res.json(result);


### PR DESCRIPTION
## Summary
- validate `houseSystem` and `nodeType` query params in API
- pass validated options through to `compute_positions`
- document defaults and allowed values for `houseSystem` and `nodeType`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c53d7cc2b0832bbf83fd4c4c3f1a51