### PR TITLE
Add Web Crypto polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ Earlier revisions used 0-based indices; tests and UI helpers now follow the
 
 - Node.js 20 or newer and npm
 
+### Web Crypto polyfill
+
+Older Node.js releases did not expose the Web Crypto API on `globalThis`. To
+support such environments the project includes a tiny polyfill that assigns
+`require('node:crypto').webcrypto` when `globalThis.crypto` is missing. Node.js
+20 provides `globalThis.crypto` out of the box so the polyfill has no effect
+there.
+
 ## Local Setup & Installation
 
 ```bash

--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,4 @@
+import '../src/polyfills/crypto.js';
 import fs from 'fs';
 import express from '../express/index.cjs';
 import path from 'path';

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,3 +1,4 @@
+import './polyfills/crypto.js';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx';

--- a/src/polyfills/crypto.js
+++ b/src/polyfills/crypto.js
@@ -1,0 +1,1 @@
+globalThis.crypto ??= require('node:crypto').webcrypto;


### PR DESCRIPTION
## Summary
- Add a simple Web Crypto polyfill for Node environments lacking global `crypto`
- Import the polyfill in both the Vite entry and server entry to ensure availability
- Document the polyfill and note that Node.js 20 includes Web Crypto natively

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c542911d58832b8a164bdce88016f2